### PR TITLE
Release page: output contact details and tidy up displayed content

### DIFF
--- a/ons_alpha/jinja2/templates/pages/release_page--cancelled.html
+++ b/ons_alpha/jinja2/templates/pages/release_page--cancelled.html
@@ -1,19 +1,14 @@
-{% extends "templates/base_page.html" %}
+{% extends "templates/pages/release_page.html" %}
 {% from "components/table-of-contents/_macro.njk" import onsTableOfContents %}
 
-{% block main %}
-    <div class="ons-u-fs-m ons-u-mt-s ons-u-pb-xxs release__document-type">Release</div>
-    <h1 class="ons-u-fs-xxxl ons-u-mb-m">
-        <span>{{ page.title }}</span>
-    </h1>
-
-    <div class="ons-grid ons-u-ml-no">
-        <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-col-12@s ons-u-p-no">
-            <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
-            <span class="ons-u-nowrap">{{ _("Cancelled") }}</span>
-        </div>
+{% block release_meta %}
+    <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-col-12@s ons-u-p-no">
+        <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
+        <span class="ons-u-nowrap">{{ _("Cancelled") }}</span>
     </div>
+{% endblock %}
 
+{% block release_note %}
     <div class="ons-u-pt-s ons-u-pb-m@m ons-u-pb-s@xxs@m">
         {% from "components/panel/_macro.njk" import onsPanel %}
     {# fmt:off #}
@@ -24,23 +19,7 @@
         }}
     {# fmt:on #}
     </div>
-
-    <div class="ons-grid ons-js-toc-container ons-u-ml-no">
-        <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-u-p-no">
-            {# fmt:off #}
-            {{-
-                onsTableOfContents({
-                    "title": 'Contents',
-                    "ariaLabel": 'Pages in this guide',
-                    "itemsList": toc
-                })
-            }}
-            {# fmt:on #}
-        </div>
-        <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
-            <section id="summary">
-                {{ page.summary|richtext() }}
-            </section>
-        </div>
-    </div>
 {% endblock %}
+
+{% block release_content %}{% endblock %} {# we want to show this only for published content #}
+{% block release_content_footer %}{% endblock %}  {# we want to show this only for published content #}

--- a/ons_alpha/jinja2/templates/pages/release_page--upcoming.html
+++ b/ons_alpha/jinja2/templates/pages/release_page--upcoming.html
@@ -1,19 +1,13 @@
-{% extends "templates/base_page.html" %}
-{% from "components/table-of-contents/_macro.njk" import onsTableOfContents %}
+{% extends "templates/pages/release_page.html" %}
 
-{% block main %}
-    <div class="ons-u-fs-m ons-u-mt-s ons-u-pb-xxs release__document-type">Release</div>
-    <h1 class="ons-u-fs-xxxl ons-u-mb-m">
-        <span>{{ page.title }}</span>
-    </h1>
-
-    <div class="ons-grid ons-u-ml-no">
-        <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-col-12@s ons-u-p-no">
-            <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
-            <span class="ons-u-nowrap">{{ page.release_date|date("j F Y g:ia") }}</span>
-        </div>
+{% block release_meta %}
+    <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-col-12@s ons-u-p-no">
+        <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
+        <span class="ons-u-nowrap">{{ page.release_date|date("j F Y g:ia") }}</span>
     </div>
+{% endblock %}
 
+{% block release_note %}
     <div class="ons-u-pt-s ons-u-pb-m@m ons-u-pb-s@xxs@m">
         {% from "components/panel/_macro.njk" import onsPanel %}
     {# fmt:off #}
@@ -24,23 +18,7 @@
         }}
     {# fmt:on #}
     </div>
-
-    <div class="ons-grid ons-js-toc-container ons-u-ml-no">
-        <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-u-p-no">
-            {# fmt:off #}
-            {{-
-                onsTableOfContents({
-                    "title": 'Contents',
-                    "ariaLabel": 'Pages in this guide',
-                    "itemsList": toc
-                })
-            }}
-            {# fmt:on #}
-        </div>
-        <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
-            <section id="summary">
-                {{ page.summary|richtext() }}
-            </section>
-        </div>
-    </div>
 {% endblock %}
+
+{% block release_content %}{% endblock %} {# we want to show this only for published content #}
+{% block release_content_footer %}{% endblock %}  {# we want to show this only for published content #}

--- a/ons_alpha/jinja2/templates/pages/release_page.html
+++ b/ons_alpha/jinja2/templates/pages/release_page.html
@@ -14,17 +14,23 @@
     </h1>
 
     <div class="ons-grid ons-u-ml-no">
-        <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-col-12@s ons-u-p-no">
-            <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
-            <span class="ons-u-nowrap">{{ page.release_date|date("j F Y g:ia") }}</span>
-        </div>
-        {% if page.next_release %}
-            <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
-                <span class="ons-u-fs-r--b">{{ _("Next release") }}:</span>
-                <span class="ons-u-nowrap">{{ page.next_release }}</span>
+        {% block release_meta %}
+            <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-col-12@s ons-u-p-no">
+                <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
+                <span class="ons-u-nowrap">{{ page.release_date|date("j F Y g:ia") }}</span>
             </div>
-        {% endif %}
+            {% if page.next_release %}
+                <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
+                    <span class="ons-u-fs-r--b">{{ _("Next release") }}:</span>
+                    <span class="ons-u-nowrap">{{ page.next_release }}</span>
+                </div>
+            {% endif %}
+
+            <p></p>{# added empty p for some margin #}
+        {% endblock release_meta %}
     </div>
+
+    {% block release_note %}{% endblock %}
 
     <div class="ons-grid ons-js-toc-container ons-u-ml-no">
         <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-u-p-no">
@@ -41,7 +47,26 @@
         <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
             {{ page.summary|richtext() }}
 
-            {% include_block page.content %}
+            {% block release_content %}
+                {% include_block page.content %}
+
+                {% if page.contact_details %}
+                    <section id="contact-details">
+                        <h2>{{ _("Contact details") }}</h2>
+
+                        <div>
+                            <h3 class="ons-u-mb-no ons-u-fs-r--b">Name</h3>
+                            <p>{{ page.contact_details.name }}</p>
+                            <h3 class="ons-u-mb-no ons-u-fs-r--b">Email</h3>
+                            <p><a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.email }}</a></p>
+                            {% if page.contact_details.phone %}
+                                <h3 class="ons-u-mb-no ons-u-fs-r--b">Phone</h3>
+                                <p><a href="tel:{{ page.contact_details.phone|urlencode() }}">{{ page.contact_details.phone }}</a></p>
+                            {% endif %}
+                        </div>
+                    </section>
+                {% endif %}
+            {% endblock release_content %}
 
             {% if page.is_accredited %}
                 <section id="about-the-data">
@@ -64,8 +89,9 @@
                 </section>
             {% endif %}
 
-            {% if related_links %}
-                {% from "components/related-content/_macro.njk" import onsRelatedContent %}
+            {% block release_content_footer %}
+                {% if related_links %}
+                    {% from "components/related-content/_macro.njk" import onsRelatedContent %}
                 {# fmt:off #}
                 <section id="links">
                     {{
@@ -82,7 +108,8 @@
                     }}
                 </section>
                 {# fmt:on #}
-            {% endif %}
+                {% endif %}
+            {% endblock %}
         </div>
     </div>
 {% endblock %}

--- a/ons_alpha/release_calendar/models.py
+++ b/ons_alpha/release_calendar/models.py
@@ -141,10 +141,13 @@ class ReleasePage(BasePage):
             for block in self.content:  # pylint: disable=not-an-iterable
                 items += block.block.to_table_of_contents_items(block.value)
 
-            if self.is_accredited:
-                items += [{"url": "#about-the-data", "text": _("About the data")}]
+            if self.contact_details_id:
+                items += [{"url": "#contact-details", "text": _("Contact details")}]
 
-            if self.related_links_for_context:
-                items += [{"url": "#links", "text": _("You might also be interested in")}]
+        if self.is_accredited:
+            items += [{"url": "#about-the-data", "text": _("About the data")}]
+
+        if self.status == ReleaseStatus.PUBLISHED and self.related_links_for_context:
+            items += [{"url": "#links", "text": _("You might also be interested in")}]
 
         return items


### PR DESCRIPTION
- less DRY via template blocks
- show the accredited logo/info everywhere