### PR TITLE
Add bulletin related links to TOC

### DIFF
--- a/ons_alpha/bulletins/blocks.py
+++ b/ons_alpha/bulletins/blocks.py
@@ -10,6 +10,7 @@ from ons_alpha.core.blocks import (
     ONSEmbedBlock,
     PanelBlock,
     RelatedContentBlock,
+    RelatedLinksBlock,
     TableBlock,
 )
 
@@ -23,11 +24,7 @@ class BulletinStoryBlock(StreamBlock):
     ons_embed = ONSEmbedBlock(group="DataVis")
     embed = EmbedBlock()
     image = ImageChooserBlock()
-    related_links = ListBlock(
-        RelatedContentBlock(),
-        icon="list-ul",
-        template="templates/components/streamfield/related_links_block.html",
-    )
+    related_links = RelatedLinksBlock(RelatedContentBlock())
 
     class Meta:
         block_counts = {"related_links": {"max_num": 1}}

--- a/ons_alpha/core/blocks/__init__.py
+++ b/ons_alpha/core/blocks/__init__.py
@@ -1,7 +1,7 @@
 from .embeddable import DocumentBlock, ImageBlock, ONSEmbedBlock
 from .markup import HeadingBlock, QuoteBlock, TableBlock, TypedTableBlock
 from .panels import CorrectionBlock, NoticeBlock, PanelBlock
-from .related import RelatedContentBlock
+from .related import RelatedContentBlock, RelatedLinksBlock
 
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "PanelBlock",
     "QuoteBlock",
     "RelatedContentBlock",
+    "RelatedLinksBlock",
     "TableBlock",
     "TypedTableBlock",
 ]

--- a/ons_alpha/core/blocks/related.py
+++ b/ons_alpha/core/blocks/related.py
@@ -2,8 +2,11 @@ from functools import cached_property
 
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
+from django.utils.text import slugify
+from django.utils.translation import gettext as _
 from wagtail.blocks import (
     CharBlock,
+    ListBlock,
     PageChooserBlock,
     StreamBlockValidationError,
     StructBlock,
@@ -62,3 +65,25 @@ class RelatedContentBlock(StructBlock):
             raise StreamBlockValidationError(block_errors=errors, non_block_errors=non_block_errors)
 
         return value
+
+
+class RelatedLinksBlock(ListBlock):
+    def __init__(self, child_block, search_index=True, **kwargs):
+        super().__init__(child_block, search_index=search_index, **kwargs)
+
+        self.heading = _("Related links")
+        self.slug = slugify(self.heading)
+
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context=parent_context)
+        context["heading"] = self.heading
+        context["slug"] = self.slug
+
+        return context
+
+    class Meta:
+        icon = "list-ul"
+        template = "templates/components/streamfield/related_links_block.html"
+
+    def to_table_of_contents_items(self, value):
+        return [{"url": "#" + self.slug, "text": self.heading}]

--- a/ons_alpha/jinja2/templates/components/streamfield/related_links_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/related_links_block.html
@@ -1,5 +1,5 @@
-<section id="{{ _("Related links")|slugify() }}">
-    <h2>{{ _("Related links") }}</h2>
+<section id="{{ slug }}">
+    <h2 >{{ heading }}</h2>
 
     <ul class="ons-list ons-list--bare">
         {% for item in value %}


### PR DESCRIPTION
The TOC tag currently extracts data from the StreamField, so any "section" block needs to define a `to_table_of_contents_items` method 