### PR TITLE
Add support for cell merging and td class

### DIFF
--- a/ons_alpha/core/blocks/markup.py
+++ b/ons_alpha/core/blocks/markup.py
@@ -1,5 +1,6 @@
 from django.utils.text import slugify
 from wagtail import blocks
+from wagtail.contrib.table_block.blocks import DEFAULT_TABLE_OPTIONS
 from wagtail.contrib.table_block.blocks import TableBlock as WagtailTableBlock
 from wagtail.contrib.typed_table_block.blocks import (
     TypedTableBlock as WagtailTypedTableBlock,
@@ -32,23 +33,75 @@ class TableBlock(WagtailTableBlock):
         icon = "info-circle"
         template = "templates/components/streamfield/table_block.html"
 
+    def __init__(self, required=True, help_text=None, table_options=None, **kwargs):
+        if table_options is None:
+            table_options = {
+                "mergeCells": True,
+                "contextMenu": DEFAULT_TABLE_OPTIONS["contextMenu"] + ["---------", "mergeCells", "alignment"],
+            }
+
+        super().__init__(required=required, help_text=help_text, table_options=table_options, **kwargs)
+
+    def _to_ons_classname(self, classname: str) -> str:
+        """
+        Reference: https://handsontable.com/docs/javascript-data-grid/text-alignment/#horizontal-and-vertical-alignment
+        """
+        match classname:
+            case "htRight":
+                return "ons-u-ta-right"
+            case "htLeft":
+                return "ons-u-ta-left"
+            case "htCenter":
+                return "ons-u-ta-center"
+            case _:
+                return ""
+
+    def _get_rows(self, value, table_header, classnames):
+        trs = []
+        data = value["data"][1:] if table_header else value.get("data", [])
+        for row_idx, row in enumerate(data, 1 if table_header else 0):
+            tds = []
+            for cell_idx, cell in enumerate(row):
+                td = {"value": cell}
+                if classname := classnames.get((row_idx, cell_idx)):
+                    td["tdClasses"] = classname
+                tds.append(td)
+
+            trs.append({"tds": tds})
+        return trs
+
     def get_context(self, value, parent_context=None):
-        context = super().get_context(value, parent_context)  #
+        context = super().get_context(value, parent_context=parent_context)
+
+        classnames = {}
+        hidden = {}
+        spans = {}
+        if value.get("cell"):
+            for meta in value["cell"]:
+                if "className" in meta:
+                    classnames[(meta["row"], meta["col"])] = self._to_ons_classname(meta["className"])
+                if "hidden" in meta:
+                    hidden[(meta["row"], meta["col"])] = meta["hidden"]
+
+        if value.get("mergeCells"):
+            for merge in value["mergeCells"]:
+                spans[(merge["row"], merge["col"])] = {
+                    "rowspan": merge["rowspan"],
+                    "colspan": merge["colspan"],
+                }
 
         table_header = (
-            [{"value": cell} for cell in value["data"][0]]
-            if value.get("data", None) and len(value["data"]) > 0 and value.get("first_row_is_table_header", False)
+            [{"value": cell or ""} for cell in value["data"][0]]
+            if value.get("data", "") and len(value["data"]) > 0 and value.get("first_row_is_table_header", False)
             else []
         )
 
+        # Note: update when https://service-manual.ons.gov.uk/design-system/components/table supports col/row spans
         return {
             "options": {
                 "caption": value.get("table_caption"),
                 "ths": table_header,
-                "trs": [
-                    {"tds": [{"value": cell} for cell in row]}
-                    for row in (value["data"][1:] if table_header else value.get("data", []))
-                ],
+                "trs": self._get_rows(value, table_header, classnames),
             },
             **context,
         }

--- a/ons_alpha/jinja2/component_overrides/table/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/table/_macro.njk
@@ -1,0 +1,72 @@
+{% macro onsTable(params) %}{# This is an override of ONS "components/table/_macro.njk" #}
+    {% from "components/button/_macro.njk" import onsButton %}
+    {% from "components/icon/_macro.njk" import onsIcon %}
+
+    {% set variants = params.variants if params.variants else '' %}
+
+    {% if 'scrollable' in variants %}
+    <div class="ons-table-scrollable ons-table-scrollable--on">
+        <div class="ons-table-scrollable__content" tabindex="0" role="region" aria-label="{{ params.caption }}. {{ params.ariaLabel | default("Scrollable table") }}">
+    {% endif %}
+            <table {% if params.id %}id="{{ params.id }}"{% endif %} class="ons-table{% if params.tableClasses %} {{ params.tableClasses }}{% endif %}{% if variants %}{% if variants is not string %}{% for variant in variants %} ons-table--{{ variant }}{% endfor %}{% else %} ons-table--{{ variants }}{% endif %}{% endif %}" {% if params.sortBy and 'sortable' in variants %}data-aria-sort="{{ params.sortBy }}" data-aria-asc="{{ params.ariaAsc }}" data-aria-desc="{{ params.ariaDesc }}"{% endif %}>
+                {% if params.caption %}
+                <caption class="ons-table__caption{{ " ons-u-vh" if params.hideCaption }}">{{ params.caption }}</caption>
+                {% endif %}
+                <thead class="ons-table__head">
+                    <tr class="ons-table__row">
+                        {% for th in params.ths %}
+                        <th scope="col" class="ons-table__header{{ ' ' + th.thClasses if th.thClasses }}{{ " ons-table__header--numeric" if th.numeric }}" {% if th.span %}{{ th.span }}{% endif %} {% if 'sortable' in variants %} aria-sort="{{- th.ariaSort | default('none') -}}"{% endif %}{% if th.widthPercentage %} width="{{ th.widthPercentage }}%"{% endif %}>
+                            <span class="ons-table__header-text">{{- th.value -}}</span>
+                            {% if 'sortable' in variants %}
+                                {{-
+                                    onsIcon({
+                                        "iconType": "sort-sprite",
+                                        "id": th.value | replace(' ', '-'),
+                                        "classes": 'ons-u-d-no'
+                                    })
+                                -}}
+                            {% endif %}
+                        </th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody class="ons-table__body">
+                    {% for tr in params.trs %}
+                    <tr class="ons-table__row{{ " ons-table__row--highlight" if tr.highlight }}" {% if tr.id %} id="{{ tr.id }}"{% endif %} {% if tr.span %}{{ tr.span }}{% endif %}>
+                        {% for td in tr.tds %}
+                        <td class="ons-table__cell{{ ' ' + td.tdClasses if td.tdClasses }}{{ " ons-table__cell--numeric" if td.numeric }}" {% if td.id %} id="{{ td.id }}"{% endif %} {% if td.span %}{{ td.span }}{% endif %} {% if td.data %} data-th="{{ td.data }}"{% endif %} {% if td.dataSort %} data-sort-value="{{ td.dataSort }}"{% endif %}>
+                            {% if td.form %}
+                                <form action="{{ td.form.action }}" method="{{ td.form.method | default('POST')}}">
+                                    {{
+                                        onsButton(td.form.button)
+                                    }}
+                                    {% if td.form.hiddenFormField %}
+                                        {% for hiddenField in td.form.hiddenFormField %}
+                                            <input type="hidden" {% if hiddenField.name %} name="{{ hiddenField.name }}"{% endif %} {% if hiddenField.value %} value="{{ hiddenField.value }}"{% endif %} />
+                                        {% endfor %}
+                                    {% endif %}
+                                </form>
+                            {% endif %}
+                            {% if td.value %}
+                                {{ td.value | safe }}
+                            {% endif %}
+                        </td>
+                        {% endfor %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                {% if params.tfoot %}
+                <tfoot class="ons-table__foot">
+                    <tr class="ons-table__row">
+                        {% for tfootCell in params.tfoot %}
+                        <td class="ons-table__cell ons-u-fs-s">{{ tfootCell.value }}</td>
+                        {% endfor %}
+                    </tr>
+                </tfoot>
+                {% endif %}
+            </table>
+        {% if 'scrollable' in variants %}
+        </div>
+    </div>
+    {% endif %}
+{% endmacro %}

--- a/ons_alpha/jinja2/templates/components/streamfield/table_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/table_block.html
@@ -1,3 +1,3 @@
-{% from "components/table/_macro.njk" import onsTable %}
+{% from "component_overrides/table/_macro.njk" import onsTable %}
 
 {{ onsTable(options) }}


### PR DESCRIPTION
### What is the context of this PR?
This stems from a question from Al. The basic Wagtail TableBlock supports cell merging as well as alignment.

Note that https://service-manual.ons.gov.uk/design-system/components/table doesn't support col/row spans and this is a potential gap

Wagtail docs reference: https://docs.wagtail.org/en/stable/reference/contrib/table_block.html#configuration-options

### How to review
Add/edit an information page or a bulletin page, add a table block in content, right click on a cell to change alignment. Select several cells to merge (although that is currently not reflected in the markup because of the DS component)
