### PR TITLE
Add basic validation for table block

### DIFF
--- a/ons_alpha/core/blocks/markup.py
+++ b/ons_alpha/core/blocks/markup.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from wagtail import blocks
@@ -94,6 +95,17 @@ class TableBlock(WagtailTableBlock):
 
             trs.append({"tds": tds})
         return trs
+
+    def clean(self, value):
+        if not value or not value.get("table_header_choice"):
+            raise ValidationError("Select an option for Table headers")
+
+        data = value.get("data", [])
+        all_cells_empty = all(not cell for row in data for cell in row)
+        if all_cells_empty:
+            raise ValidationError("Table cannot be empty")
+
+        return super().clean(value)
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)

--- a/ons_alpha/core/blocks/markup.py
+++ b/ons_alpha/core/blocks/markup.py
@@ -103,7 +103,7 @@ class TableBlock(WagtailTableBlock):
         data = value.get("data", [])
         all_cells_empty = all(not cell for row in data for cell in row)
         if all_cells_empty:
-            raise ValidationError("Table cannot be empty")
+            raise ValidationError("The table cannot be empty")
 
         return super().clean(value)
 


### PR DESCRIPTION
### What is the context of this PR?
The Table block was causing errors when selected but not configured, due to accessing `value` in `get_context` which might not exist. This PR introduces basic validation to ensure the table is configured and that the cells are not empty. No advanced logic for cell validation has been added; it simply checks that the cells are not completely empty.

### How to review
- Sense check.
- Select a Table block on a bulletin page and verify that the Preview does not display any errors.
- Ensure that a validation error is raised if no data is added to the table cells