### PR TITLE
Custom scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ fab migrate
 fab start
 ```
 
-This will start the containers in the background, but not Django. To do this, connect to the web container with `fab sh` 
-and run `djrun` or `./manage.py runserver 0.0.0.0:8000` to run Django in the foreground.
+This will start the containers in the background, but not Django. To do this, connect to the web container with `fab sh`
+and run `honcho start` to start both Django and the scheduler in the foreground.
+
+If you only want to run Django, run `honcho start web` or `./manage.py runserver 0.0.0.0:8000`.
 
 Then, connect to the running container again (`fab sh`) and:
 
@@ -155,5 +157,3 @@ This project uses `Ruff`, `pylint`, and `black` for linting and formatting Pytho
   ```sh
   make format
   ```
-
-

--- a/docker/Procfile
+++ b/docker/Procfile
@@ -1,0 +1,2 @@
+web: python manage.py runserver 0.0.0.0:8000
+scheduler: python manage.py scheduler

--- a/docker/bashrc.sh
+++ b/docker/bashrc.sh
@@ -6,4 +6,5 @@ if [ "$BUILD_ENV" = "dev" ]; then
     alias djrun="python manage.py runserver 0.0.0.0:8000"
     alias djrunplus="python manage.py runserver_plus 0.0.0.0:8000"
     alias djtest="python manage.py test --settings=ons_alpha.settings.test"
+    alias honcho="honcho -f docker/Procfile"
 fi

--- a/heroku.yml
+++ b/heroku.yml
@@ -7,3 +7,8 @@ release:
   image: web
   command:
     - django-admin createcachetable && django-admin migrate --noinput
+run:
+  scheduler:
+    image: web
+    command:
+      - django-admin scheduler

--- a/ons_alpha/core/management/commands/scheduler.py
+++ b/ons_alpha/core/management/commands/scheduler.py
@@ -1,0 +1,35 @@
+import atexit
+import logging
+import signal
+
+from apscheduler.executors.pool import ThreadPoolExecutor
+from apscheduler.schedulers.blocking import BlockingScheduler
+from django.core.management.base import BaseCommand
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        self.scheduler = BlockingScheduler(executors={"default": ThreadPoolExecutor()})
+
+        self.setup_signals()
+
+        self.configure_scheduler()
+
+        logger.info("Starting scheduler")
+        self.scheduler.start()
+
+    def setup_signals(self):
+        signal.signal(signal.SIGINT, self.shutdown)
+        signal.signal(signal.SIGTERM, self.shutdown)
+        atexit.register(self.shutdown)
+
+    def shutdown(self, *args, **kwargs):
+        if self.scheduler.running:
+            logger.info("Shutting down scheduler")
+            self.scheduler.shutdown(wait=False)
+
+    def configure_scheduler(self):
+        pass

--- a/ons_alpha/core/management/commands/scheduler.py
+++ b/ons_alpha/core/management/commands/scheduler.py
@@ -11,8 +11,8 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    def handle(self, **options):
-        self.scheduler = BlockingScheduler(executors={"default": ThreadPoolExecutor()})
+    def handle(self, **options):  # pylint: disable=W0221
+        self.scheduler = BlockingScheduler(executors={"default": ThreadPoolExecutor()})  # pylint: disable=W0201
 
         self.setup_signals()
 
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         signal.signal(signal.SIGTERM, self.shutdown)
         atexit.register(self.shutdown)
 
-    def shutdown(self, *args, **kwargs):
+    def shutdown(self, _signum, _frame):
         if self.scheduler.running:
             self.scheduler.shutdown(wait=False)
 

--- a/ons_alpha/core/management/commands/scheduler.py
+++ b/ons_alpha/core/management/commands/scheduler.py
@@ -34,4 +34,5 @@ class Command(BaseCommand):
         self.scheduler.add_job(func, name=command_name, trigger=trigger)
 
     def configure_scheduler(self):
+        # "second=0" run the task every minute, on the minute (ie when the seconds = 0)
         self.add_management_command("publish_scheduled", CronTrigger(second=0))

--- a/ons_alpha/settings/base.py
+++ b/ons_alpha/settings/base.py
@@ -421,6 +421,11 @@ LOGGING = {
             "level": "WARNING",
             "propagate": False,
         },
+        "apscheduler": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -881,6 +881,23 @@ testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
 tornado = ["tornado (>=0.2)"]
 
 [[package]]
+name = "honcho"
+version = "1.1.0"
+description = "Honcho: a Python clone of Foreman. For managing Procfile-based applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "honcho-1.1.0-py2.py3-none-any.whl", hash = "sha256:a4d6e3a88a7b51b66351ecfc6e9d79d8f4b87351db9ad7e923f5632cc498122f"},
+    {file = "honcho-1.1.0.tar.gz", hash = "sha256:c5eca0bded4bef6697a23aec0422fd4f6508ea3581979a3485fc4b89357eb2a9"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+export = ["jinja2 (>=2.7,<3)"]
+
+[[package]]
 name = "identify"
 version = "2.6.0"
 description = "File identification library for Python"
@@ -2310,4 +2327,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "6eb715a480af92d9ee3f5f28b7be00a8c9e1f6273e7c8c2775273614e963d83f"
+content-hash = "aa8657aabff3765227146a29df4f0a67c97e10f85493198b96b0ed8afeb9428d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,34 @@ files = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.10.4"
+description = "In-process task scheduler with Cron-like capabilities"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "APScheduler-3.10.4-py3-none-any.whl", hash = "sha256:fb91e8a768632a4756a585f79ec834e0e27aad5860bac7eaa523d9ccefd87661"},
+    {file = "APScheduler-3.10.4.tar.gz", hash = "sha256:e6df071b27d9be898e486bc7940a7be50b4af2e9da7c08f0744a96d4bd4cef4a"},
+]
+
+[package.dependencies]
+pytz = "*"
+six = ">=1.4.0"
+tzlocal = ">=2.0,<3.dev0 || >=4.dev0"
+
+[package.extras]
+doc = ["sphinx", "sphinx-rtd-theme"]
+gevent = ["gevent"]
+mongodb = ["pymongo (>=3.0)"]
+redis = ["redis (>=3.0)"]
+rethinkdb = ["rethinkdb (>=2.4.0)"]
+sqlalchemy = ["sqlalchemy (>=1.4)"]
+testing = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-tornado5"]
+tornado = ["tornado (>=4.3)"]
+twisted = ["twisted"]
+zookeeper = ["kazoo"]
+
+[[package]]
 name = "asgiref"
 version = "3.8.1"
 description = "ASGI specs, helper code, and adapters"
@@ -1941,6 +1969,23 @@ files = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.2"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tzlocal-5.2-py3-none-any.whl", hash = "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8"},
+    {file = "tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
+
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2265,4 +2310,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "b1ac7ff38abdf24c54295c49616bc54e6f33177671e1c68c696bf6f2226fbeea"
+content-hash = "6eb715a480af92d9ee3f5f28b7be00a8c9e1f6273e7c8c2775273614e963d83f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pylint = "^3.2.4"
 black = "^24.4.2"  # keep version in sync with .pre-commit-config.toml
 djhtml = "~3.0.6"
 setuptools = "^70.2.0"
+honcho = "^1.1.0"
 
 [build-system]
 requires = ["poetry>=1,<2"]
@@ -124,7 +125,3 @@ omit = [
 
 [tool.coverage.report]
 show_missing = true
-
-[tool.poetry.plugins.dotenv]
-ignore = "false"
-location = ".env"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ boto3 = "^1.34.55"
 django-jinja = "^2.11.0"
 wagtailcharts = "^0.5.0"
 wagtail-font-awesome-svg = "^1.0.1"
+apscheduler = "^3.10.4"
 
 [tool.poetry.group.dev.dependencies]
 Werkzeug = "~3.0.3"


### PR DESCRIPTION
https://jira.ons.gov.uk/browse/NWP-262

### What is the context of this PR?

It's critical that pages are published as close to their publish time as possible. Using an external scheduler adds additional latency. Instead, run a permanent process which handles scheduling of jobs. This ensures the process is already running, and can immediately execute jobs. 

From testing, jobs are executed almost immediately (single-digit milliseconds). A simple run of `publish_scheduled` locally with a single page to publish took 50ms (this **will** get larger as the site content grows).

For `honcho` to work, you may need to completely rebuild the container (and/or recreate the virtualenv).

### How to review

This PR adds a new management command `scheduler` which runs the relevant commands.
