### PR TITLE
Allow embedding documents in content

### DIFF
--- a/ons_alpha/core/blocks/__init__.py
+++ b/ons_alpha/core/blocks/__init__.py
@@ -1,4 +1,4 @@
-from .embeddable import DocumentBlock, ImageBlock, ONSEmbedBlock
+from .embeddable import DocumentBlock, DocumentsBlock, ImageBlock, ONSEmbedBlock
 from .markup import HeadingBlock, QuoteBlock, TableBlock, TypedTableBlock
 from .panels import CorrectionBlock, NoticeBlock, PanelBlock
 from .related import RelatedContentBlock, RelatedLinksBlock
@@ -19,4 +19,5 @@ __all__ = [
     "TableBlock",
     "TypedTableBlock",
     "ChartChooserBlock",
+    "DocumentsBlock",
 ]

--- a/ons_alpha/core/blocks/embeddable.py
+++ b/ons_alpha/core/blocks/embeddable.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.template.defaultfilters import filesizeformat
 from wagtail import blocks
 from wagtail.blocks import StructBlockValidationError
 from wagtail.documents.blocks import DocumentChooserBlock
@@ -14,13 +16,45 @@ class ImageBlock(blocks.StructBlock):
         template = "templates/components/streamfield/image_block.html"
 
 
+class DocumentBlockStructValue(blocks.StructValue):
+    def as_macro_data(self):
+        return {
+            "thumbnail": True,
+            "url": self["document"].url,
+            "title": self["title"] or self["document"].filename,
+            "description": self["description"],
+            "metadata": {
+                "file": {
+                    "fileType": self["document"].file_extension.upper(),
+                    "fileSize": filesizeformat(self["document"].get_file_size()),
+                }
+            },
+        }
+
+
 class DocumentBlock(blocks.StructBlock):
     document = DocumentChooserBlock()
     title = blocks.CharBlock(required=False)
+    description = blocks.RichTextBlock(features=settings.RICH_TEXT_BASIC, required=False)
 
     class Meta:
         icon = "doc-full-inverse"
+        value_class = DocumentBlockStructValue
         template = "templates/components/streamfield/document_block.html"
+
+
+class DocumentsBlock(blocks.StreamBlock):
+    document = DocumentBlock()
+
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context)
+        context["macro_data"] = [document.value.as_macro_data() for document in value]
+        return context
+
+    class Meta:
+        block_counts = {"document": {"min_num": 1}}
+        icon = "doc-full-inverse"
+        template = "templates/components/streamfield/documents_block.html"
 
 
 ONS_EMBED_PREFIX = "https://www.ons.gov.uk/visualisations/"

--- a/ons_alpha/core/blocks/embeddable.py
+++ b/ons_alpha/core/blocks/embeddable.py
@@ -21,7 +21,7 @@ class DocumentBlockStructValue(blocks.StructValue):
         return {
             "thumbnail": True,
             "url": self["document"].url,
-            "title": self["title"] or self["document"].filename,
+            "title": self["title"] or self["document"].title,
             "description": self["description"],
             "metadata": {
                 "file": {

--- a/ons_alpha/core/blocks/stream_blocks.py
+++ b/ons_alpha/core/blocks/stream_blocks.py
@@ -6,6 +6,7 @@ from wagtailmath.blocks import MathBlock
 from ons_alpha.core.blocks import (
     ChartChooserBlock,
     CorrectionBlock,
+    DocumentsBlock,
     HeadingBlock,
     NoticeBlock,
     ONSEmbedBlock,
@@ -22,6 +23,7 @@ class CoreStoryBlock(StreamBlock):
     panel = PanelBlock()
     embed = EmbedBlock()
     image = ImageChooserBlock()
+    documents = DocumentsBlock()
     related_links = RelatedLinksBlock(RelatedContentBlock())
     table = TableBlock(group="DataVis")
     equation = MathBlock(icon="decimal", group="DataVis")

--- a/ons_alpha/jinja2/templates/components/streamfield/documents_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/documents_block.html
@@ -1,3 +1,3 @@
 {% from "components/document-list/_macro.njk" import onsDocumentList %}
 
-{{ onsDocumentList({"documents": [value.as_macro_data()]}) }}
+{{ onsDocumentList({"documents": macro_data}) }}


### PR DESCRIPTION
### What is the context of this PR?

Add the ability to embed documents in content, styled by the DS: https://service-manual.ons.gov.uk/design-system/components/document-list.

Not all the DS features are exposed, as they require varying levels of extra work. But the core functionality is there, and can be expanded as time goes on.

### How to review

![image](https://github.com/user-attachments/assets/19a79e3f-7f35-4369-8faa-9506639151b5)
