### PR TITLE
Add the stable branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, stable]
   pull_request:
-    branches: [main]
+    branches: [main, stable]
 
 concurrency:
   group: "${{ github.head_ref || github.ref }}-${{ github.workflow }}"


### PR DESCRIPTION
I've added a [`stable` branch](https://github.com/ONSdigital/dis-wagtail-alpha/tree/stable) off 0e3534a8 which is the commit that https://ons-alpha.torchbox.dev/ is currently on.
The goal is to configure autodeployments off `stable`
