### PR TITLE
Use single cache for renditions and default cache

### DIFF
--- a/ons_alpha/settings/base.py
+++ b/ons_alpha/settings/base.py
@@ -222,14 +222,9 @@ if REDIS_URL:
     CACHES = {
         "default": {
             "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": REDIS_URL + "/0",
+            "LOCATION": REDIS_URL,
             "OPTIONS": redis_options,
-        },
-        "renditions": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": REDIS_URL + "/1",
-            "OPTIONS": redis_options,
-        },
+        }
     }
     DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
 else:


### PR DESCRIPTION
### What is the context of this PR?

The intention is to use a Redis cluster, which doesn't play nicely with multiple databases when using `redis-py`. Using a single Redis database won't cause any issues, and will perhaps save some resources by only using a single connection.

### How to review

Basic smoke test.

Deployments will cache-miss for a while, but otherwise there should be no impact. 
