### PR TITLE
Enforce collection restrictions on images

### DIFF
--- a/ons_alpha/images/models.py
+++ b/ons_alpha/images/models.py
@@ -1,5 +1,22 @@
+from typing import NamedTuple
+
+from django.core.files.base import ContentFile
 from django.db import models
 from wagtail.images.models import AbstractImage, AbstractRendition, Image
+
+
+class StubImage(NamedTuple):
+    """
+    A stub image class for use when generating rendition image URLs.
+    """
+
+    id: int
+
+    @property
+    def file(self):
+        # HACK: Provide a blank filename to satisfy `reverse`,
+        # but the view never uses it.
+        return ContentFile("", name="")
 
 
 class CustomImage(AbstractImage):
@@ -11,3 +28,16 @@ class Rendition(AbstractRendition):
 
     class Meta:
         unique_together = (("image", "filter_spec", "focal_point_key"),)
+
+    @property
+    def media_url(self):
+        return super().url
+
+    @property
+    def url(self):
+        """
+        Redirect uses of the rendition to a view which checks permissions.
+        """
+        from wagtail.images.views.serve import generate_image_url  # pylint: disable=import-outside-toplevel
+
+        return generate_image_url(StubImage(self.image_id), self.filter_spec)

--- a/ons_alpha/images/views.py
+++ b/ons_alpha/images/views.py
@@ -1,0 +1,42 @@
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.views.generic import RedirectView
+from wagtail.images import get_image_model
+from wagtail.images.exceptions import InvalidFilterSpecError
+from wagtail.images.models import SourceImageIOError
+from wagtail.images.utils import verify_signature
+
+
+Image = get_image_model()
+
+
+class ONSImageServeView(RedirectView):
+    """
+    A modified version of Wagtail's `ImageServeView` which validates collection permissions before serving.
+    """
+
+    def get_redirect_url(self, signature, image_id, filter_spec, *args, **kwargs):  # pylint: disable=arguments-differ
+        if not verify_signature(signature.encode(), image_id, filter_spec):
+            raise PermissionDenied
+
+        image = get_object_or_404(Image.objects.select_related("collection"), id=image_id)
+
+        if not all(
+            restriction.accept_request(self.request) for restriction in image.collection.get_view_restrictions()
+        ):
+            raise PermissionDenied
+
+        try:
+            rendition = image.get_rendition(filter_spec)
+        except SourceImageIOError:
+            return HttpResponse("Source image file not found", content_type="text/plain", status=410)
+        except InvalidFilterSpecError:
+            return HttpResponse(
+                f"Invalid filter spec: {filter_spec}",
+                content_type="text/plain",
+                status=400,
+            )
+
+        # NB: .url is overridden
+        return rendition.media_url

--- a/ons_alpha/urls.py
+++ b/ons_alpha/urls.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from django.views.decorators.cache import never_cache
 from django.views.decorators.vary import vary_on_headers
 from django.views.generic import TemplateView
@@ -11,6 +11,7 @@ from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
+from ons_alpha.images.views import ONSImageServeView
 from ons_alpha.search import views as search_views
 from ons_alpha.utils.cache import get_default_cache_control_decorator
 
@@ -31,7 +32,10 @@ private_urlpatterns += [
 ]
 
 # Public URLs that are meant to be cached.
-urlpatterns = [path("sitemap.xml", sitemap)]
+urlpatterns = [
+    path("sitemap.xml", sitemap),
+    re_path(r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$", ONSImageServeView.as_view(), name="wagtailimages_serve"),
+]
 
 if settings.DEBUG:
     from django.conf.urls.static import static


### PR DESCRIPTION
### What is the context of this PR?

Unlike Documents, Wagtail doesn't enforce collection view restrictions on images. 

This PR forces images to route through a given view, which does these checks.

The checks work for the `{% image %}`, the `{% image_url %}` tag, as well as any manual retrievals of the rendition's URL through its `.url`.

See also https://docs.wagtail.org/en/stable/advanced_topics/images/image_serve_view.html

### How to review

Creating a collection with the various restrictions, and confirm they're enforced.

Note that unlike documents and pages, this PR doesn't add the ability to fix the permissions issue (eg redirect to a password or login screen).
