### PR TITLE
Bundles: audit log and slack notifications

### DIFF
--- a/ons_alpha/bundles/forms.py
+++ b/ons_alpha/bundles/forms.py
@@ -33,6 +33,8 @@ class BundleAdminForm(WagtailAdminModelForm):
         self.fields["approved_by"].disabled = True
         self.fields["approved_by"].widget = forms.HiddenInput()
 
+        self.original_status = self.instance.status
+
     def _validate_bundled_pages(self):
         for idx, form in enumerate(self.formsets["bundled_pages"].forms):
             if not form.is_valid():

--- a/ons_alpha/bundles/management/commands/publish_bundles.py
+++ b/ons_alpha/bundles/management/commands/publish_bundles.py
@@ -1,8 +1,10 @@
 import time
 import uuid
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from django.urls import reverse
 from django.utils import timezone
 from wagtail.log_actions import log
 
@@ -13,6 +15,8 @@ from ons_alpha.release_calendar.models import ReleaseStatus
 
 
 class Command(BaseCommand):
+    base_url: str = ""
+
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run",
@@ -47,8 +51,11 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle_bundle(self, bundle: Bundle):
+        # only provide a URL if we can generate a full one
+        inspect_url = self.base_url + reverse("bundle:inspect", args=(bundle.pk,)) if self.base_url else None
+
         start_time = time.time()
-        notify_slack_of_publication_start(bundle)
+        notify_slack_of_publication_start(bundle, url=inspect_url)
         for page in bundle.get_bundled_pages():
             if (revision := page.scheduled_revision) is None:
                 continue
@@ -63,7 +70,7 @@ class Command(BaseCommand):
         bundle.status = BundleStatus.RELEASED
         bundle.save()
 
-        notify_slack_of_publish_end(bundle, time.time() - start_time)
+        notify_slack_of_publish_end(bundle, time.time() - start_time, url=inspect_url)
 
         log(action="wagtail.publish.scheduled", instance=bundle)
 
@@ -72,6 +79,8 @@ class Command(BaseCommand):
         if options["dry_run"]:
             self.stdout.write("Will do a dry run.")
             dry_run = True
+
+        self.base_url = getattr(settings, "WAGTAILADMIN_BASE_URL", "")
 
         bundles_to_publish = Bundle.objects.filter(status=BundleStatus.APPROVED, release_date__lte=timezone.now())
         if dry_run:

--- a/ons_alpha/bundles/management/commands/publish_bundles.py
+++ b/ons_alpha/bundles/management/commands/publish_bundles.py
@@ -3,6 +3,7 @@ import uuid
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils import timezone
+from wagtail.log_actions import log
 
 from ons_alpha.bundles.enums import BundleStatus
 from ons_alpha.bundles.models import Bundle
@@ -57,6 +58,8 @@ class Command(BaseCommand):
 
         bundle.status = BundleStatus.RELEASED
         bundle.save()
+
+        log(action="wagtail.publish.scheduled", instance=bundle)
 
     def handle(self, *args, **options):
         dry_run = False

--- a/ons_alpha/bundles/notifications.py
+++ b/ons_alpha/bundles/notifications.py
@@ -1,0 +1,102 @@
+import logging
+
+from typing import TYPE_CHECKING, Optional
+
+from django.conf import settings
+from slack_sdk.webhook import WebhookClient
+
+from ons_alpha.bundles.models import Bundle
+
+
+if TYPE_CHECKING:
+    from ons_alpha.users.models import User
+
+
+logger = logging.getLogger("ons_alpha.bundles")
+
+
+def notify_slack_of_status_change(
+    bundle: Bundle, old_status: str, user: Optional["User"] = None, url: Optional[str] = None
+):
+    if (webhook_url := settings.SLACK_NOTIFICATIONS_WEBHOOK_URL) is None:
+        return
+
+    client = WebhookClient(webhook_url)
+
+    fields = [
+        {"title": "Title", "value": bundle.name, "short": True},
+        {"title": "Changed by", "value": user.get_full_name() if user else "System", "short": True},
+        {"title": "Old status", "value": old_status, "short": True},
+        {"title": "New status", "value": bundle.get_status_display(), "short": True},
+    ]
+    if url:
+        fields.append(
+            {"title": "Link", "value": url, "short": False},
+        )
+
+    response = client.send(
+        text="Bundle status changed",
+        attachments=[{"color": "good", "fields": fields}],
+        unfurl_links=False,
+        unfurl_media=False,
+    )
+
+    if response.status_code != 200:
+        logger.error("Unable to notify Slack of bundle status change: %s", response.body)
+
+
+def notify_slack_of_publication_start(bundle: Bundle, user: Optional["User"] = None, url: Optional[str] = None):
+    if (webhook_url := settings.SLACK_NOTIFICATIONS_WEBHOOK_URL) is None:
+        return
+
+    client = WebhookClient(webhook_url)
+
+    fields = [
+        {"title": "Title", "value": bundle.name, "short": True},
+        {"title": "User", "value": user.get_full_name() if user else "System", "short": True},
+        {"title": "Pages", "value": bundle.get_bundled_pages().count(), "short": True},
+        {"title": "Datasets", "value": len(bundle.datasets.raw_data), "short": True},
+    ]
+    if url:
+        fields.append(
+            {"title": "Link", "value": url, "short": False},
+        )
+
+    response = client.send(
+        text="Starting bundle publication",
+        attachments=[{"color": "good", "fields": fields}],
+        unfurl_links=False,
+        unfurl_media=False,
+    )
+
+    if response.status_code != 200:
+        logger.error("Unable to notify Slack of bundle status change: %s", response.body)
+
+
+def notify_slack_of_publish_end(bundle: Bundle, elapsed, user: Optional["User"] = None, url: Optional[str] = None):
+    if (webhook_url := settings.SLACK_NOTIFICATIONS_WEBHOOK_URL) is None:
+        return
+
+    client = WebhookClient(webhook_url)
+
+    fields = [
+        {"title": "Title", "value": bundle.name, "short": True},
+        {"title": "User", "value": user.get_full_name() if user else "System", "short": True},
+        {"title": "Pages", "value": bundle.get_bundled_pages().count(), "short": True},
+        {"title": "Datasets", "value": len(bundle.datasets.raw_data), "short": True},
+        {"title": "Total time", "value": f"{elapsed:.3f} seconds"},
+    ]
+    if url:
+        fields.append(
+            {"title": "Link", "value": url, "short": False},
+        )
+
+    response = client.send(
+        text="Finished bundle publication",
+        attachments=[{"color": "good", "fields": fields}],
+        unfurl_links=False,
+        unfurl_media=False,
+    )
+
+    if response.status_code != 200:
+        logger.error("Unable to notify Slack of bundle status change: %s", response.body)

--- a/ons_alpha/bundles/viewsets.py
+++ b/ons_alpha/bundles/viewsets.py
@@ -1,3 +1,5 @@
+import time
+
 from functools import cached_property
 
 from django.http import HttpRequest
@@ -15,6 +17,7 @@ from wagtail.log_actions import log
 
 from .enums import BundleStatus
 from .models import Bundle
+from .notifications import notify_slack_of_publication_start, notify_slack_of_publish_end, notify_slack_of_status_change
 
 
 class BundleCreateView(CreateView):
@@ -29,6 +32,8 @@ class BundleCreateView(CreateView):
 class BundleEditView(EditView):
     actions = ["edit", "save-and-approve", "publish"]
     template_name = "bundles/wagtailadmin/edit.html"
+    has_content_changes: bool = False
+    start_time: float = None
 
     def dispatch(self, request: HttpRequest, *args, **kwargs):
         if (instance := self.get_object()) and instance.status == BundleStatus.RELEASED:
@@ -59,17 +64,23 @@ class BundleEditView(EditView):
 
             if "status" in self.form.changed_data:
                 kwargs = {"content_changed": self.has_content_changes}
+                original_status = BundleStatus[self.form.original_status].label
+                url = self.request.build_absolute_uri(reverse("bundle:inspect", args=(instance.pk,)))
+
                 if instance.status == BundleStatus.APPROVED.value:
                     action = "bundles.approve"
-                    kwargs["data"] = {"old": BundleStatus[self.form.original_status].label}
+                    kwargs["data"] = {"old": original_status}
+                    notify_slack_of_status_change(instance, original_status, user=self.request.user, url=url)
                 elif instance.status == BundleStatus.RELEASED.value:
                     action = "wagtail.publish"
+                    self.start_time = time.time()
                 else:
                     action = "bundles.update_status"
                     kwargs["data"] = {
-                        "old": BundleStatus[self.form.original_status].label,
+                        "old": original_status,
                         "new": instance.get_status_display(),
                     }
+                    notify_slack_of_status_change(instance, original_status, user=self.request.user, url=url)
 
                 # now log the status change
                 log(
@@ -81,10 +92,14 @@ class BundleEditView(EditView):
         return instance
 
     def run_after_hook(self):
-        if self.action == "publish":
+        if self.action == "publish" or (self.action == "edit" and self.object.status == BundleStatus.RELEASED):
+            notify_slack_of_publication_start(self.object, user=self.request.user)
+            start_time = self.start_time or time.time()
             for page in self.object.get_bundled_pages():
                 if page.current_workflow_state:
                     page.current_workflow_state.current_task_state.approve(user=self.request.user)
+
+            notify_slack_of_publish_end(self.object, time.time() - start_time, user=self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/ons_alpha/settings/base.py
+++ b/ons_alpha/settings/base.py
@@ -797,7 +797,10 @@ CRISPY_FAIL_SILENTLY = False  # Default for local development. Gets overridden.
 # from third-party applications like PayPal or Zoom as needed
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
 
+# Note: SLACK_PUBLISH_NOTIFICATION_WEBHOOK_URL is used specifically in the "after_publish_page" Wagtail hook
+# whereas SLACK_NOTIFICATIONS_WEBHOOK_URL is intended for general notifications
 SLACK_PUBLISH_NOTIFICATION_WEBHOOK_URL = env.get("SLACK_PUBLISH_NOTIFICATION_WEBHOOK_URL")
+SLACK_NOTIFICATIONS_WEBHOOK_URL = env.get("SLACK_NOTIFICATIONS_WEBHOOK_URL")
 
 SHORT_DATETIME_FORMAT = "d/m/Y P"
 


### PR DESCRIPTION
Builds on #49 and:

- [x] adds custom log actions for bundle approval and status change
- [x] logs the approval, publication, scheduled publication and other status changes
- [x] sends a Slack notification when the status changes

<details>
<summary>Status change notification</summary>

![Screenshot 2024-09-11 at 15 38 50](https://github.com/user-attachments/assets/386dac93-5407-48c0-985d-1bc8090e58ab)
</details>


<details>
<summary>Publishing notification</summary>

![Screenshot 2024-09-11 at 15 39 09](https://github.com/user-attachments/assets/ed4589a0-4476-4355-b672-63f1733477a2)
</details>

<details>
<summary>History</summary>

![Screenshot 2024-09-11 at 15 40 19](https://github.com/user-attachments/assets/d9ba4e39-2704-405c-aefe-b5955c2566f8)
</details>