### PR TITLE
Allow web concurrency to be modified at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV PATH=$VIRTUAL_ENV/bin:$PATH \
     POETRY_INSTALL_ARGS=${POETRY_INSTALL_ARGS} \
     PYTHONUNBUFFERED=1 \
     DJANGO_SETTINGS_MODULE=ons_alpha.settings.production \
+    WEB_CONCURRENCY=2 \
     PORT=8000
 
 # Make $BUILD_ENV available at runtime

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -17,8 +17,5 @@ accesslog = "-"
 # Time out after 25 seconds (notably shorter than Heroku's)
 timeout = 25
 
-# Workers can be overridden by `$WEB_CONCURRENCY`
-workers = 2
-
 # Load app pre-fork to save memory and worker startup time
 preload_app = True


### PR DESCRIPTION
### What is the context of this PR?

Allow tweaking the number of web workers per container through environment variables.

Config overrides environment variables, for some reason.


### How to review

There is no functional change in this PR, however running gunicorn with a different `WEB_CONCURRENCY` will run that number of processes, rather than just 2.
