### PR TITLE
Add .python-version to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 /npm-debug.log
 /.idea/
 .vscode
+.python-version
 coverage
 
 # Distribution / packaging


### PR DESCRIPTION
This file is useful for some editor setups, but shouldn't really be committed to the repo, as it can get in the way of being running fab commands. The project runs in Docker, where the python version is hardcoded elsewhere... pinning it here too means that developers need to install a whole new version of Python just to set up the project, which is overkill.