### PR TITLE
Clear gunicorn's default date format to restore milliseconds

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -21,6 +21,10 @@ timeout = 25
 # Load app pre-fork to save memory and worker startup time
 preload_app = True
 
-# Add milliseconds to gunicorn's log messages
-gunicorn.glogging.Logger.datefmt = None
-del gunicorn.glogging.CONFIG_DEFAULTS["formatters"]["generic"]["datefmt"]
+
+class CustomLogger(gunicorn.glogging.Logger):
+    # Clear custom date format so logs include milliseconds
+    datefmt = None
+
+
+logger_class = CustomLogger

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,4 +1,5 @@
 import gunicorn
+import gunicorn.glogging
 
 
 # Tell gunicorn to run our app
@@ -19,3 +20,7 @@ timeout = 25
 
 # Load app pre-fork to save memory and worker startup time
 preload_app = True
+
+# Add milliseconds to gunicorn's log messages
+gunicorn.glogging.Logger.datefmt = None
+del gunicorn.glogging.CONFIG_DEFAULTS["formatters"]["generic"]["datefmt"]


### PR DESCRIPTION
### What is the context of this PR?

Python's `logging` only adds the milliseconds if no custom format is provided:

https://github.com/python/cpython/blob/28aea5d07d163105b42acd81c1651397ef95ea57/Lib/logging/__init__.py#L648-L655

Clearing `gunicorn`'s format falls back to the default, which includes milliseconds. It drops the square brackets, but that's fine.

https://github.com/benoitc/gunicorn/blob/903792f152af6a27033d458020923cb2bcb11459/gunicorn/glogging.py#L81

https://github.com/benoitc/gunicorn/blob/903792f152af6a27033d458020923cb2bcb11459/gunicorn/glogging.py#L176

This means `gunicorn`s startup messages contain milliseconds, which is useful for certain benchmarking measurements. Note this doesn't affect log messages from Django, as these are handled by a separate logger.

### How to review

Run `gunicorn`, and notice that milliseconds are now added to the log timestamps:

```
ons_alpha@c6fe46cec3bc:/app$ gunicorn
2024-09-17 16:14:56,536 [13] [INFO] Starting gunicorn 22.0.0
2024-09-17 16:14:56,537 [13] [INFO] Listening at: http://0.0.0.0:8000 (13)
2024-09-17 16:14:56,537 [13] [INFO] Using worker: sync
2024-09-17 16:14:56,542 [14] [INFO] Booting worker with pid: 14
```
