### PR TITLE
Ensure our custom workflow tasks send notifications

### DIFF
--- a/ons_alpha/workflows/apps.py
+++ b/ons_alpha/workflows/apps.py
@@ -8,3 +8,9 @@ class WorkflowsAppConfig(AppConfig):
         # note: using a monkey patch until https://github.com/wagtail/wagtail/pull/6025 is fixed
         # Currently scheduled for 6.3 in November
         import ons_alpha.workflows.monkey_patches  # noqa pylint: disable=unused-import,import-outside-toplevel
+
+        from ons_alpha.workflows.signal_handlers import (  # pylint: disable=import-outside-toplevel
+            register_signal_handlers,
+        )
+
+        register_signal_handlers()

--- a/ons_alpha/workflows/models.py
+++ b/ons_alpha/workflows/models.py
@@ -1,4 +1,5 @@
 from django.utils.translation import gettext_lazy as _
+from wagtail.admin.mail import GroupApprovalTaskStateSubmissionEmailNotifier
 from wagtail.models import AbstractGroupApprovalTask
 
 
@@ -30,3 +31,12 @@ class ReadyToPublishGroupTask(AbstractGroupApprovalTask):
     class Meta:
         verbose_name = _("Ready to publish Group approval task")
         verbose_name_plural = _("Ready to publish Group approval tasks")
+
+
+class TaskStateSubmissionEmailNotifier(GroupApprovalTaskStateSubmissionEmailNotifier):
+    """A notifier to send email updates for our submission events"""
+
+    def can_handle(self, instance, **kwargs):
+        return isinstance(instance, self.valid_classes) and isinstance(
+            instance.task.specific, (ReadOnlyGroupTask, ReadyToPublishGroupTask)
+        )

--- a/ons_alpha/workflows/signal_handlers.py
+++ b/ons_alpha/workflows/signal_handlers.py
@@ -1,0 +1,15 @@
+from wagtail.models import TaskState
+from wagtail.signals import task_submitted
+
+from ons_alpha.workflows.models import TaskStateSubmissionEmailNotifier
+
+
+task_submission_email_notifier = TaskStateSubmissionEmailNotifier()
+
+
+def register_signal_handlers():
+    task_submitted.connect(
+        task_submission_email_notifier,
+        sender=TaskState,
+        dispatch_uid="ons_group_approval_task_submitted_email_notification",
+    )


### PR DESCRIPTION
Spotted this yesterday while going over business area capabilities

reference: https://github.com/wagtail/wagtail/blob/6affa04d320f50b6a3babd8afc1a590e02e84a5d/wagtail/admin/mail.py#L368-L373 - `GroupApprovalTaskStateSubmissionEmailNotifier` checks we have a `GroupApprovalTask` instance, but our tasks inherit from `AbstractGroupApprovalTask`