### PR TITLE
Fix: Image list crashing with ValueError

### DIFF
--- a/ons_alpha/images/views.py
+++ b/ons_alpha/images/views.py
@@ -5,7 +5,7 @@ from wagtail.images.views.serve import ServeView
 class ImageServeView(ServeView):
     def serve(self, rendition):
         # If there's no reason (within our control) for the file not to be served by S3, redirect
-        if rendition.image.is_public and rendition.image.acls_last_set > rendition.image.privacy_last_changed:
+        if rendition.image.is_public and rendition.image.acls_are_up_to_date():
             return redirect(rendition.file.url)
         # Serve the file until it is no longer private, or ACLs have been updated successfully
         return super().serve(rendition)

--- a/ons_alpha/private_media/models.py
+++ b/ons_alpha/private_media/models.py
@@ -184,6 +184,13 @@ class PrivateMediaCollectionMember(CollectionMember):
     def is_public(self) -> bool:
         return not self.is_private
 
+    def acls_are_up_to_date(self) -> bool:
+        if self.privacy_last_changed is None:
+            return True
+        if self.acls_last_set is None:
+            return False
+        return self.acls_last_set > self.privacy_last_changed
+
     def determine_privacy(self) -> bool:
         was_private = self.is_private
         privacy_changed = False
@@ -315,7 +322,7 @@ class PrivateAbstractRendition(AbstractRendition):
         """
         from wagtail.images.views.serve import generate_image_url  # pylint: disable=import-outside-toplevel
 
-        if self.image.is_public and self.image.acls_last_set > self.image.privacy_last_changed:
+        if self.image.is_public and self.image.acls_are_up_to_date():
             return self.file.url
         return generate_image_url(self.image, self.filter_spec)
 


### PR DESCRIPTION
Resolves: https://torchbox.sentry.io/issues/5939713253/events/616114a170b54ec0a36c00f41330b527/?project=4507498919755776

Moves datetime comparison logic to a separate `acls_are_up_to_date()` method, so that None values can be accounted for.

The problem stems from the fact that new fields were added to the model, so existing images exist with `None` values for some of the automatically-managed datetimes. This was missed in local development, because it was carried out in a newly-built environment without any existing objects.
