### PR TITLE
Fix: TypeError raised by PrivateMediaManager.bulk_set_file_acls() in reporting stage

### DIFF
--- a/ons_alpha/private_media/models.py
+++ b/ons_alpha/private_media/models.py
@@ -103,7 +103,7 @@ class PrivateMediaManager(models.Manager):
 
         results = utils.set_file_acls(all_files, acl_name)
 
-        for obj, files in files_by_object:
+        for obj, files in files_by_object.items():
             if all(results.get(file) for file in files):
                 obj.acls_last_set = timezone.now()
                 successfully_updated_objects.append(obj)


### PR DESCRIPTION
`files_by_object` is a dict, so we need to use `.items()` to iterate through keys and values