### PR TITLE
Fix: TOC missing when when BulletinSeriesPage or ArticleSeriesPage renders the latest item

### DIFF
--- a/ons_alpha/articles/models.py
+++ b/ons_alpha/articles/models.py
@@ -186,8 +186,7 @@ class ArticleSeriesPage(RoutablePageMixin, Page):
         latest = self.get_latest()
         if not latest:
             raise Http404
-
-        return self.render(request, context_overrides={"page": latest}, template="templates/pages/article_page.html")
+        return latest.serve(request)
 
     @path("previous-releases/")
     def previous_releases(self, request):

--- a/ons_alpha/bulletins/models.py
+++ b/ons_alpha/bulletins/models.py
@@ -181,8 +181,7 @@ class BulletinSeriesPage(RoutablePageMixin, Page):
         latest = self.get_latest()
         if not latest:
             raise Http404
-
-        return self.render(request, context_overrides={"page": latest}, template="templates/pages/bulletin_page.html")
+        return latest.serve(request)
 
     @path("previous-releases/")
     def previous_releases(self, request):


### PR DESCRIPTION
Currently, the `latest` route for these page types renders the latest page using the same template and object, but fails to add additional things to the context in the same way that the pages themselves do.

If we want to render the `latest` items exactly as they would be rendered if visited directly, we should call the `serve()` method of those pages instead.