### PR TITLE
Prototype: Add 'noindex' tag to all pages (BE)

### DIFF
--- a/ons_alpha/core/tests/test_context_processors.py
+++ b/ons_alpha/core/tests/test_context_processors.py
@@ -10,7 +10,7 @@ class GlobalVarsContextProcessorTest(TestCase):
         request = RequestFactory().get("/")
         self.assertEqual(
             global_vars(request),
-            {"GOOGLE_TAG_MANAGER_ID": "", "SEO_NOINDEX": False, "LANGUAGE_CODE": "en-gb", "IS_EXTERNAL_ENV": False},
+            {"GOOGLE_TAG_MANAGER_ID": "", "SEO_NOINDEX": True, "LANGUAGE_CODE": "en-gb", "IS_EXTERNAL_ENV": False},
         )
 
     def test_when_tracking_settings_defined(self):
@@ -23,7 +23,7 @@ class GlobalVarsContextProcessorTest(TestCase):
             global_vars(request),
             {
                 "GOOGLE_TAG_MANAGER_ID": "GTM-123456",
-                "SEO_NOINDEX": False,
+                "SEO_NOINDEX": True,
                 "LANGUAGE_CODE": "en-gb",
                 "IS_EXTERNAL_ENV": False,
             },

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -3,6 +3,7 @@
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 
 {% block meta %}
+    {{ super() }}
     {% if SEO_NOINDEX %}
         <meta name="robots" content="noindex">
     {% endif %}

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -2,6 +2,12 @@
 {% from "component_overrides/header/_macro.njk" import onsHeaderNew %}
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 
+{% block meta %}
+    {% if SEO_NOINDEX %}
+        <meta name="robots" content="noindex">
+    {% endif %}
+{% endblock meta %}
+
 {# fmt:off #}
 {% set languages = languages | default([
     {

--- a/ons_alpha/jinja2/templates/base_page.html
+++ b/ons_alpha/jinja2/templates/base_page.html
@@ -1,9 +1,7 @@
 {% extends "templates/base.html" %}
 
 {% block meta %}
-    {% if SEO_NOINDEX %}
-        <meta name="robots" content="noindex">
-    {% endif %}
+    {{ super() }}
     {% with current_site=wagtail_site() %}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content="@{{ settings.core.SocialMediaSettings.twitter_handle }}" />

--- a/ons_alpha/jinja2/templates/base_page.html
+++ b/ons_alpha/jinja2/templates/base_page.html
@@ -1,6 +1,9 @@
 {% extends "templates/base.html" %}
 
 {% block meta %}
+    {% if SEO_NOINDEX %}
+        <meta name="robots" content="noindex">
+    {% endif %}
     {% with current_site=wagtail_site() %}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:site" content="@{{ settings.core.SocialMediaSettings.twitter_handle }}" />

--- a/ons_alpha/settings/base.py
+++ b/ons_alpha/settings/base.py
@@ -783,7 +783,7 @@ GOOGLE_TAG_MANAGER_ID = env.get("GOOGLE_TAG_MANAGER_ID")
 
 
 # Allows us to toggle search indexing via an environment variable.
-SEO_NOINDEX = env.get("SEO_NOINDEX", "false").lower() == "true"
+SEO_NOINDEX = env.get("SEO_NOINDEX", "true").lower() == "true"
 
 TESTING = "test" in sys.argv
 


### PR DESCRIPTION
Use the 'SEO_NOINDEX' context variable (added by `core.context_processors.global_vars`) to conditionally include a noindex tag on all pages (whether a Wagtail page or otherwise)

### How to review
- View the home page and inspect the source. You should see `<meta name="robots" content="noindex">` in the `<head>` of the page HTML.
- To remove it, add `SEO_NOINDEX = False` to your `local.py` settings file to override the default and restart
- View the home page and inspect the source again. The `<meta name="robots" content="noindex">` should no longer be present.
