### PR TITLE
Styling for headline figures

### DIFF
--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -1,11 +1,17 @@
-<div class="ons-headline-figures">
-    {% for figure in value %}
-        <div class="ons-headline-figure">
-            <p class="ons-headline-figure__title">{{ figure.title }}</p>
-            <p class="ons-headline-figure__figure">{{ figure.figure }}</p>
-            {% if figure.supporting_text %}
-                <p class="ons-headline-figure__supporting_text">{{ figure.supporting_text }}</p>
-            {% endif %}
-        </div>
-    {% endfor %}
+<div class="ons-container headline-figures">
+    <h2 class="headline-figures__heading ons-u-fs-l">Headline figures</h2>
+    <div class="ons-grid ons-grid--flex-gap ons-grid--gap-24 headline-figures__grid">
+        {% for figure in value %}
+            <div class="ons-grid__col">
+                <div class="headline-figures__block">
+                    <h3 class="headline-figures__title ons-u-fs-l">{{ figure.title }}</h3>
+                    <p class="headline-figures__figure">{{ figure.figure }}</p>
+
+                    {% if figure.supporting_text %}
+                        <p class="headline-figures__supporting-text ons-u-fs-r">{{ figure.supporting_text }}</p>
+                    {% endif %}
+                </div>
+            </div>
+        {% endfor %}
+    </div>
 </div>

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -71,13 +71,12 @@
             {% endblock %}
         </div>
     </div>
-{% endblock %}
-
-{% block main %}
     {% if page.headline_figures %}
         {% include_block page.headline_figures %}
     {% endif %}
+{% endblock %}
 
+{% block main %}
     <div class="ons-container">
         <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
             <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -1,0 +1,63 @@
+.headline-figures {
+    padding-top: 24px;
+    padding-bottom: 40px;
+
+    &__grid {
+        row-gap: 24px;
+    }
+
+    &__block {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        height: 100%;
+        column-gap: 40px;
+        background-color: var(--ons-color-ocean-blue);
+        color: var(--ons-color-white);
+        padding: 24px;
+
+        @media (min-width: 500px) {
+            display: flex;
+            flex-direction: column;
+        }
+    }
+
+    &__heading {
+        line-height: 1.333;
+        margin-bottom: 16px;
+
+        @media (min-width: 980px) {
+            line-height: 1.385;
+        }
+    }
+
+    &__title {
+        line-height: 1.333;
+
+        @media (min-width: 980px) {
+            line-height: 1.385;
+        }
+    }
+
+    &__figure {
+        // font-sizes don't match design system type scale in the figma file
+        font-size: 1.7rem;
+        font-weight: 700;
+        line-height: 1.46;
+        margin-bottom: 0;
+
+        @media (min-width: 980px) {
+            margin-top: auto;
+        }
+
+        @media (min-width: 980px) {
+            font-size: 2rem;
+            line-height: 1.27;
+        }
+    }
+
+    &__supporting-text {
+        line-height: 1.555;
+        margin-bottom: 0;
+        grid-column: 1 / span 2;
+    }
+}

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
@@ -22,6 +22,10 @@ $grid-gutters: 1rem;
     &--gap-32 {
         column-gap: 32px;
     }
+
+    &--gap-24 {
+        column-gap: 24px;
+    }
 }
 
 .ons-grid__col {

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -2,6 +2,7 @@
 @use 'components/bulletin-header';
 @use 'components/button-nav';
 @use 'components/footer';
+@use 'components/headline-figures';
 @use 'components/navigation';
 
 // ONS design system overrides


### PR DESCRIPTION
### What is the context of this PR?
[Link to ticket](https://jira.ons.gov.uk/browse/NWP-488)
Adds styling for the headline figures block on the bulletin page

### How to review
Test a bulletin page on your local build

### Screenshots
<details>
<summary>Click to expand</summary>

**Desktop:**
![Screenshot 2024-10-10 at 11 25 08](https://github.com/user-attachments/assets/cafc2674-c201-4d61-83bb-0916e9d03c7f)


**Mobile:**
![Screenshot 2024-10-10 at 11 26 04](https://github.com/user-attachments/assets/f234d747-06d3-404d-8828-4b6d91a17ec3)


</details>
