### PR TITLE
Prototype: Restrict headline figure blocks to a single item

### DIFF
--- a/ons_alpha/bulletins/models.py
+++ b/ons_alpha/bulletins/models.py
@@ -46,7 +46,7 @@ class BulletinPage(BundledPageMixin, RoutablePageMixin, BasePage):
         related_name="+",
     )
     is_accredited = models.BooleanField(default=False)
-    headline_figures = StreamField([("figures", HeadlineFiguresBlock())], blank=True)
+    headline_figures = StreamField([("figures", HeadlineFiguresBlock())], blank=True, max_num=1)
     body = StreamField(CoreStoryBlock(), use_json_field=True)
     updates = StreamField(CorrectionsNoticesStoryBlock(), blank=True, use_json_field=True)
 

--- a/ons_alpha/topics/models.py
+++ b/ons_alpha/topics/models.py
@@ -77,7 +77,7 @@ class TopicPage(BaseTopicPage):
     ]
     page_description = "A specific topic page. e.g. Public sector finance or Inflation and price indices"
 
-    headline_figures = StreamField([("figures", HeadlineFiguresBlock())], blank=True)
+    headline_figures = StreamField([("figures", HeadlineFiguresBlock())], blank=True, max_num=1)
     body = StreamField(
         [
             ("featured_document", FeaturedDocumentBlock()),


### PR DESCRIPTION
### What is the context of this PR?
Currently, it's possible to add multiple instances of ``HeadlineFiguresBlock`` to each page, when we only ever want a single instance to be added. These changes enforce that at the field level, so that editors can only add a single item.
