### PR TITLE
Design system updates

### DIFF
--- a/ons_alpha/jinja2/component_overrides/footer/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/footer/_macro.njk
@@ -185,35 +185,37 @@
                                 {% endif %}
                             </div>
                         {% endif %}
-                        {% if not params.footerLogo.logos.logo1 %}
-                            {%
-                                set logo1 = {
-                                    'logoUrl': 'https://cy.ons.gov.uk/' if lang == 'cy' else 'https://www.ons.gov.uk/',
-                                    'logoImage': onsLogo | safe
-                                }
-                            %}
-                            {% set logos = [logo1, params.footerLogo.logos.logo2] %}
-                        {% else %}
-                            {% set logos = [params.footerLogo.logos.logo1, params.footerLogo.logos.logo2] %}
-                        {% endif %}
+                        {% if params.footerLogo %}
+                            {% if not params.footerLogo.logos.logo1 %}
+                                {%
+                                    set logo1 = {
+                                        'logoUrl': 'https://cy.ons.gov.uk/' if lang == 'cy' else 'https://www.ons.gov.uk/',
+                                        'logoImage': onsLogo | safe
+                                    }
+                                %}
+                                {% set logos = [logo1, params.footerLogo.logos.logo2] %}
+                            {% else %}
+                                {% set logos = [params.footerLogo.logos.logo1, params.footerLogo.logos.logo2] %}
+                            {% endif %}
 
-                        <div
-                            class="ons-footer__logo-container ons-u-mb-l ons-grid-flex ons-grid-flex--vertical-top{{ ' ons-grid-flex--between' if params.footerLogo.display == 'split' else "" }}"
-                        >
-                            {% for logo in logos %}
-                                {%- if logo.logoUrl -%}
-                                    <a
-                                        class="ons-footer__logo-link{{ ' ons-u-mr-s' if extraLogo and loop.index == 1 else "" }}"
-                                        href="{{ logo.logoUrl }}"
-                                        >{{ logo.logoImage | safe }}</a
-                                    >
-                                {%- else -%}
+                            <div
+                                class="ons-footer__logo-container ons-u-mb-l ons-grid-flex ons-grid-flex--vertical-top{{ ' ons-grid-flex--between' if params.footerLogo.display == 'split' else "" }}"
+                            >
+                                {% for logo in logos %}
+                                    {%- if logo.logoUrl -%}
+                                        <a
+                                            class="ons-footer__logo-link{{ ' ons-u-mr-s' if extraLogo and loop.index == 1 else "" }}"
+                                            href="{{ logo.logoUrl }}"
+                                            >{{ logo.logoImage | safe }}</a
+                                        >
+                                    {%- else -%}
 
-                                    {{ logo.logoImage | safe }}
-                                {% endif %}
-                            {% endfor %}
+                                        {{ logo.logoImage | safe }}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                     {% if params.crest %}
                         <!-- Crest -->
                         <div class="ons-grid__col ons-footer__crest ons-u-mb-l@2xs@l">

--- a/ons_alpha/jinja2/component_overrides/footer/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/footer/_macro.njk
@@ -84,7 +84,6 @@
                             <!-- Full footer columns -->
                             <div class="ons-grid__col ons-col-4@m{{ ' ons-u-mt-l@2xs@m' if loop.index > 1 }}">
                                 {% if col.title %}
-                                    {# todo: check change in utility class here #}
                                     <h2 class="footer__heading ons-footer__heading ons-u-fs-l">{{ col.title }}</h2>
                                 {% endif %}
                                 {{
@@ -113,7 +112,6 @@
                 </div>
 
                 {% if (params.cols) or (params.rows) %}
-                    {# todo: check change of utility class here #}
                     <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
                         <div class="ons-grid__col">
                             <hr class="ons-footer__hr footer__hr" />
@@ -138,8 +136,7 @@
 
                         {% if params.oglLink %}
                             <!-- OGL -->
-                            {# todo: check utility class here - previously removed when it was mb-m #}
-                            <div class="ons-footer__license footer__licence ons-u-mb-l">
+                            <div class="ons-footer__license footer__licence">
                                 {# hard-code the ogl icon in order to override the inline fill to set the colour #}
                                 <svg
                                     class="ons-footer__ogl-img footer__ogl-img{{ iconClasses }}"

--- a/ons_alpha/jinja2/component_overrides/footer/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/footer/_macro.njk
@@ -7,12 +7,12 @@
     {% else %}
         {% set lang = 'en' %}
     {% endif %}
-
+    {% set extraLogo = params.footerLogo.logos.logo2 %}
     {% set onsLogo %}
         {% if params.lang == 'cy' %}
             {{-
                 onsIcon({
-                    "iconType": 'ons-logo-cy',
+                    "iconType": 'ons-logo-stacked-cy' if extraLogo else 'ons-logo-cy',
                     "altText": 'Swyddfa Ystadegau Gwladol',
                     "altTextId": 'ons-logo-cy-footer-alt'
                 })
@@ -20,7 +20,7 @@
         {% else %}
             {{-
                 onsIcon({
-                    "iconType": 'ons-logo-en',
+                    "iconType": 'ons-logo-stacked-en' if extraLogo else 'ons-logo-en' ,
                     "altText": 'Office for National Statistics',
                     "altTextId": 'ons-logo-en-footer-alt'
                 })
@@ -69,19 +69,22 @@
             data-analytics="footer"
             {% if params.attributes %}{% for attribute, value in (params.attributes) %}{{ ' ' }}{{ attribute }}="{{ value }}"{% endfor %}{% endif %}
         >
-            <div class="ons-container{{ ' ons-container--full-width' if params.fullWidth }}{{ ' ons-container--wide' if params.wide }}">
+            <div
+                class="ons-container{{ ' ons-container--full-width' if params.fullWidth else "" }}{{ ' ons-container--wide' if params.wide else "" }}"
+            >
                 <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
                     {% if params.newTabWarning %}
                         <div class="ons-grid__col">
-                            <p class="ons-u-fs-s ons-u-mb-m ons-footer__new-tab-warning">{{ params.newTabWarning | safe }}</p>
+                            <p class="ons-u-fs-s ons-u-mb-l ons-footer__new-tab-warning">{{ params.newTabWarning | safe }}</p>
                         </div>
                     {% endif %}
 
                     {% if params.cols %}
                         {% for col in params.cols %}
                             <!-- Full footer columns -->
-                            <div class="ons-grid__col ons-col-4@m{{ ' ons-u-mt-m@xxs@m' if loop.index > 1 }}">
+                            <div class="ons-grid__col ons-col-4@m{{ ' ons-u-mt-l@2xs@m' if loop.index > 1 }}">
                                 {% if col.title %}
+                                    {# todo: check change in utility class here #}
                                     <h2 class="footer__heading ons-footer__heading ons-u-fs-l">{{ col.title }}</h2>
                                 {% endif %}
                                 {{
@@ -110,14 +113,15 @@
                 </div>
 
                 {% if (params.cols) or (params.rows) %}
-                <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
-                    <div class="ons-grid__col">
-                        <hr class="ons-footer__hr footer__hr" />
-                     </div>
-                </div>
+                    {# todo: check change of utility class here #}
+                    <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
+                        <div class="ons-grid__col">
+                            <hr class="ons-footer__hr footer__hr" />
+                        </div>
+                    </div>
                 {% endif %}
 
-                <div class="ons-grid ons-grid--flex ons-grid--vertical-top ons-grid--between">
+                <div class="ons-grid{{ ' ons-grid-flex' if params.crest else "" }} ons-grid-flex--vertical-top ons-grid-flex--between">
                     <div class="ons-grid__col">
                         {% if params.legal %}
                             <!-- Legal -->
@@ -132,9 +136,10 @@
                             {% endfor %}
                         {% endif %}
 
-                        {% if params.OGLLink %}
+                        {% if params.oglLink %}
                             <!-- OGL -->
-                            <div class="ons-footer__license footer__licence">
+                            {# todo: check utility class here - previously removed when it was mb-m #}
+                            <div class="ons-footer__license footer__licence ons-u-mb-l">
                                 {# hard-code the ogl icon in order to override the inline fill to set the colour #}
                                 <svg
                                     class="ons-footer__ogl-img footer__ogl-img{{ iconClasses }}"
@@ -152,46 +157,66 @@
                                         fill="#F5F5F6"
                                     ></path>
                                 </svg>
-                                {% if params.OGLLink.HTML %}
-                                    {{ params.OGLLink.HTML | safe }}
-                                {% elif params.OGLLink %}
+                                {% if params.oglLink.html %}
+                                    {{ params.oglLink.html | safe }}
+                                {% elif params.oglLink %}
                                     <div>
                                         {% from "components/external-link/_macro.njk" import onsExternalLink %}
                                         {% if params.lang == 'cy' %}
-                                            {{ params.OGLLink.pre | default('Mae’r holl gynnwys ar gael o dan y') }}
+                                            {{ params.oglLink.pre | default('Mae’r holl gynnwys ar gael o dan y') }}
                                             {{
                                                 onsExternalLink({
-                                                    "url": params.OGLLink.url | default('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'),
-                                                    "linkText": params.OGLLink.link | default('Drwydded Llywodraeth Leol v3.0'),
+                                                    "url": params.oglLink.url | default('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'),
+                                                    "text": params.oglLink.text | default('Drwydded Llywodraeth Leol v3.0'),
                                                     "classes": 'footer__external-link'
                                                 })
-                                            }}{{ params.OGLLink.post | default(', oni bai y nodir fel arall') }}
+                                            }}{{ params.oglLink.post | default(', oni bai y nodir fel arall') }}
                                         {% else %}
-                                            {{ params.OGLLink.pre | default('All content is available under the') }}
+                                            {{ params.oglLink.pre | default('All content is available under the') }}
                                             {{
                                                 onsExternalLink({
-                                                    "url": params.OGLLink.url | default('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'),
-                                                    "linkText": params.OGLLink.link | default('Open Government Licence v3.0'),
+                                                    "url": params.oglLink.url | default('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'),
+                                                    "text": params.oglLink.text | default('Open Government Licence v3.0'),
                                                     "classes": 'footer__external-link'
                                                 })
-                                            }}{{ params.OGLLink.post | default(', except where otherwise stated') }}
+                                            }}{{ params.oglLink.post | default(', except where otherwise stated') }}
                                         {% endif %}
                                     </div>
                                 {% endif %}
                             </div>
                         {% endif %}
-                        {% if not params.poweredBy %}
-                            <a
-                                class="ons-footer__poweredBy-link"
-                                {% if lang == "cy" %}href="https://cy.ons.gov.uk/"{% else %}href="https://www.ons.gov.uk/"{% endif %}
-                            >
-                                <div class="ons-footer__poweredby-logo ons-u-mb-m">{{ onsLogo | safe }}</div>
-                            </a>
+                        {% if not params.footerLogo.logos.logo1 %}
+                            {%
+                                set logo1 = {
+                                    'logoUrl': 'https://cy.ons.gov.uk/' if lang == 'cy' else 'https://www.ons.gov.uk/',
+                                    'logoImage': onsLogo | safe
+                                }
+                            %}
+                            {% set logos = [logo1, params.footerLogo.logos.logo2] %}
+                        {% else %}
+                            {% set logos = [params.footerLogo.logos.logo1, params.footerLogo.logos.logo2] %}
                         {% endif %}
+
+                        <div
+                            class="ons-footer__logo-container ons-u-mb-l ons-grid-flex ons-grid-flex--vertical-top{{ ' ons-grid-flex--between' if params.footerLogo.display == 'split' else "" }}"
+                        >
+                            {% for logo in logos %}
+                                {%- if logo.logoUrl -%}
+                                    <a
+                                        class="ons-footer__logo-link{{ ' ons-u-mr-s' if extraLogo and loop.index == 1 else "" }}"
+                                        href="{{ logo.logoUrl }}"
+                                        >{{ logo.logoImage | safe }}</a
+                                    >
+                                {%- else -%}
+
+                                    {{ logo.logoImage | safe }}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
                     </div>
                     {% if params.crest %}
                         <!-- Crest -->
-                        <div class="ons-grid__col ons-footer__crest ons-u-mb-m@xxs@l">
+                        <div class="ons-grid__col ons-footer__crest ons-u-mb-l@2xs@l">
                             {{-
                                 onsIcon({
                                     "iconType": 'crest'
@@ -200,15 +225,12 @@
                         </div>
                     {% endif %}
                 </div>
-                {% if params.poweredBy %}
-                    {{ params.poweredBy | safe }}
-                {% endif %}
                 {% if params.copyrightDeclaration %}
                     <!-- Copyright -->
                     {% set copyrightDeclaration = '&copy; ' + params.copyrightDeclaration.copyright + '<br /> ' + params.copyrightDeclaration.text %}
-                    <div class="ons-grid ons-grid--flex ons-grid--vertical-bottom ons-grid--between">
+                    <div class="ons-grid ons-grid-flex ons-grid-flex--between">
                         <div class="ons-grid__col">
-                            <p class="ons-u-fs-s ons-u-mb-no ons-footer__copyright">{{- copyrightDeclaration | safe -}}</p>
+                            <p class="ons-u-fs-s ons-u-mb-l ons-footer__copyright">{{- copyrightDeclaration | safe -}}</p>
                         </div>
                     </div>
                 {% endif %}

--- a/ons_alpha/jinja2/component_overrides/footer/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/footer/_macro.njk
@@ -72,7 +72,7 @@
             <div
                 class="ons-container{{ ' ons-container--full-width' if params.fullWidth else "" }}{{ ' ons-container--wide' if params.wide else "" }}"
             >
-                <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
+                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
                     {% if params.newTabWarning %}
                         <div class="ons-grid__col">
                             <p class="ons-u-fs-s ons-u-mb-l ons-footer__new-tab-warning">{{ params.newTabWarning | safe }}</p>
@@ -114,7 +114,7 @@
 
                 {% if (params.cols) or (params.rows) %}
                     {# todo: check change of utility class here #}
-                    <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
+                    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
                         <div class="ons-grid__col">
                             <hr class="ons-footer__hr footer__hr" />
                         </div>

--- a/ons_alpha/jinja2/component_overrides/header/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/header/_macro.njk
@@ -37,9 +37,9 @@
             }}
         {% endif %}
         <div class="ons-header__top">
-            <div class="ons-container {{ ' ons-container--full-width' if params.fullWidth }}{{ ' ons-container--wide' if params.wide }}">
+            <div class="ons-container{{ ' ons-container--full-width' if params.fullWidth }}{{ ' ons-container--wide' if params.wide }}">
                 <div
-                    class="ons-header__grid-top ons-grid ons-grid--flex ons-grid--between{{ ' '+ params.mastheadLogo.classes if params.mastheadLogo.classes }}{{ ' ons-grid--no-wrap ons-grid--gutterless' if not params.mastheadLogo.multipleLogos }}"
+                    class="ons-header__grid-top ons-grid ons-grid-flex ons-grid-flex--between{{ ' '+ params.mastheadLogo.classes if params.mastheadLogo.classes }}{{ ' ons-grid-flex--no-wrap ons-grid--gutterless' if not params.mastheadLogo.multipleLogos }}"
                 >
                     <div class="ons-grid__col ons-col-auto">
                         {%- if not params.mastheadLogo.multipleLogos -%}
@@ -83,8 +83,8 @@
                                 {% set logos = [params.mastheadLogo.multipleLogos.logo1, params.mastheadLogo.multipleLogos.logo2, params.mastheadLogo.multipleLogos.logo3] %}
                                 {% for logo in logos %}
                                     {% set mastheadLogo %}
-                                        {% if logo.logoImage != "ONS Logo" %}
-                                            {{ logo.logoImage | safe }}
+                                        {% if logo.image != "ONS Logo" %}
+                                            {{ logo.image | safe }}
                                         {% else %}
                                             {{-
                                                 onsIcon({
@@ -94,8 +94,8 @@
                                             -}}
                                         {% endif %}
                                     {% endset %}
-                                    {% if logo.logoURL %}
-                                        <a class="ons-header__org-logo-link" href="{{ logo.logoURL }}">{{ mastheadLogo | safe }}</a>
+                                    {% if logo.url %}
+                                        <a class="ons-header__org-logo-link" href="{{ logo.url }}">{{ mastheadLogo | safe }}</a>
                                     {% else %}
                                         {{ mastheadLogo | safe }}
                                     {% endif %}

--- a/ons_alpha/jinja2/component_overrides/header/_macro.njk
+++ b/ons_alpha/jinja2/component_overrides/header/_macro.njk
@@ -139,7 +139,7 @@
                 >
                     {% if params.navLinks.keyLinksList %}
                         <div class="ons-container">
-                            <ul class="ons-grid ons-grid--flex-gap ons-grid--gap-40  navigation__key-links ons-list ons-list--bare">
+                            <ul class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40  navigation__key-links ons-list ons-list--bare">
                                 {% for item in params.navLinks.keyLinksList %}
                                     {# for november prototype, nav items can have text and no link - later we would want to test that both are present before outputting an li #}
                                     {% if item.text %}
@@ -162,7 +162,7 @@
                     {% endif %}
                     {% if params.navLinks.itemsList %}
                         <div class="ons-container">
-                            <ul class="ons-grid ons-grid--flex-gap ons-grid--gap-40 ons-list ons-list--bare">
+                            <ul class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 ons-list ons-list--bare">
                                 {% for item in params.navLinks.itemsList %}
                                     <li class="ons-grid__col ons-col-4@m ons-u-mb-no">
                                         {% for link in item.linksList %}

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -403,7 +403,6 @@
     ],
     "legal": [
     ],
-    "poweredBy": '&nbsp;',
     "oglLink": True,
     "footerLogo": {
     },

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -405,7 +405,8 @@
     ],
     "poweredBy": '&nbsp;',
     "oglLink": True,
-    "footerLogo": {},
+    "footerLogo": {
+    },
     })
     }}
 {% endblock %}

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -260,7 +260,7 @@
                 ]
             }
         ],
-        "OGLLink": {
+        "oglLink": {
             "pre": 'All content is available under the',
             "link": 'Open Government Licence v3.0',
             "url": 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
@@ -404,7 +404,8 @@
     "legal": [
     ],
     "poweredBy": '&nbsp;',
-    "OGLLink": true
+    "oglLink": True,
+    "footerLogo": {},
     })
     }}
 {% endblock %}

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -1,6 +1,6 @@
 <div class="ons-container headline-figures">
     <h2 class="headline-figures__heading ons-u-fs-l">Headline figures</h2>
-    <div class="ons-grid ons-grid--flex-gap ons-grid--gap-24 headline-figures__grid">
+    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--24 headline-figures__grid">
         {% for figure in value %}
             <div class="ons-grid__col">
                 <div class="headline-figures__block">

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -12,7 +12,7 @@
 
                 <div class="ons-grid ons-grid-flex-gap">
                     <div class="ons-grid__col ons-col-10@m ">
-                        <h1 class="ons-u-fs-xxxl bulletin-header__heading">
+                        <h1 class="ons-u-fs-3xl bulletin-header__heading">
                             {{ page.full_title }}
                         </h1>
                     </div>

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -10,7 +10,7 @@
                 {% include "templates/components/navigation/breadcrumbs.html" %}
                 <p class="ons-u-fs-l bulletin-header__doc-type">{{ page.document_type|default("Analysis") }}</p>
 
-                <div class="ons-grid ons-grid--flex-gap">
+                <div class="ons-grid ons-grid-flex-gap">
                     <div class="ons-grid__col ons-col-10@m ">
                         <h1 class="ons-u-fs-xxxl bulletin-header__heading">
                             {{ page.full_title }}
@@ -32,7 +32,7 @@
 
             {% block release_meta %}
                 <div class="ons-container">
-                    <div class="ons-grid ons-grid--flex-gap ons-grid--gap-40 bulletin-header__releases">
+                    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
                         <div class="ons-grid__col ons-col-4@m">
                             <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
                             <span class="ons-u-nowrap">{{ page.release_date|date("j F Y") }}</span>
@@ -50,7 +50,7 @@
                             <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
                         </div>
                     </div>
-                    <div class="ons-grid ons-grid--flex-gap ons-grid--gap-40 bulletin-header__releases">
+                    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
                         <div class="ons-grid__col ons-col-4@m">
                             {% if page.next_release_date %}
                                 <span class="ons-u-fs-r--b">{{ _("Next release") }}:</span>
@@ -82,7 +82,7 @@
 
 {% block main %}
     <div class="ons-container">
-        <div class="ons-grid ons-grid--flex-gap ons-grid--gap-32">
+        <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
             <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
                 {# fmt:off #}
                 {{-

--- a/ons_alpha/jinja2/templates/pages/index_page.html
+++ b/ons_alpha/jinja2/templates/pages/index_page.html
@@ -13,7 +13,6 @@
         <div class="grid">
             {% if subpages.object_list %}
                 <div class="ons-container">
-                    {# todo: check #}
                     <div class="ons-grid ons-grid--column@xxs@s">
                         {% for subpage in subpages %}
                             {%- set card_text -%}

--- a/ons_alpha/jinja2/templates/pages/index_page.html
+++ b/ons_alpha/jinja2/templates/pages/index_page.html
@@ -13,6 +13,7 @@
         <div class="grid">
             {% if subpages.object_list %}
                 <div class="ons-container">
+                    {# todo: check #}
                     <div class="ons-grid ons-grid--column@xxs@s">
                         {% for subpage in subpages %}
                             {%- set card_text -%}

--- a/ons_alpha/jinja2/templates/pages/methodology_page.html
+++ b/ons_alpha/jinja2/templates/pages/methodology_page.html
@@ -5,7 +5,7 @@
 
 {% block main %}
     <div class="ons-u-fs-m ons-u-mt-s ons-u-pb-xxs release__document-type">Methodology</div>
-    <h1 class="ons-u-fs-xxxl ons-u-mb-m">
+    <h1 class="ons-u-fs-3xl ons-u-mb-m">
         <span>{{ page.full_title }}</span>
     </h1>
 

--- a/ons_alpha/jinja2/templates/pages/release_page.html
+++ b/ons_alpha/jinja2/templates/pages/release_page.html
@@ -4,7 +4,7 @@
 
 {% block main %}
     <div class="ons-u-fs-m ons-u-mt-s ons-u-pb-xxs release__document-type">Release</div>
-    <h1 class="ons-u-fs-xxxl ons-u-mb-m">
+    <h1 class="ons-u-fs-3xl ons-u-mb-m">
         <span>{{ page.title }}</span>
         {% if page.is_accredited %}
             <a href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/" class="national-statistics__link ons-u-ml-s">

--- a/ons_alpha/jinja2/templates/pages/topics/topic_section_page.html
+++ b/ons_alpha/jinja2/templates/pages/topics/topic_section_page.html
@@ -11,7 +11,6 @@
 
     {% if subpages %}
         {% if subpages.object_list %}
-            {# todo: check #}
             <div class="ons-grid ons-grid--column@xxs@s">
                 {% for subpage in subpages %}
                     {%- set card_text -%}

--- a/ons_alpha/jinja2/templates/pages/topics/topic_section_page.html
+++ b/ons_alpha/jinja2/templates/pages/topics/topic_section_page.html
@@ -11,6 +11,7 @@
 
     {% if subpages %}
         {% if subpages.object_list %}
+            {# todo: check #}
             <div class="ons-grid ons-grid--column@xxs@s">
                 {% for subpage in subpages %}
                     {%- set card_text -%}

--- a/ons_alpha/static_src/sass/components/_bulletin-header.scss
+++ b/ons_alpha/static_src/sass/components/_bulletin-header.scss
@@ -6,8 +6,8 @@
     background-color: #efeff0;
     /* stylelint-enable */
     position: relative;
-    padding-bottom: rem-spacing(64);
-    margin-bottom: rem-spacing(24);
+    padding-bottom: rem-sizing(64);
+    margin-bottom: rem-sizing(24);
 
     &::before {
         position: absolute;
@@ -36,16 +36,16 @@
 
     &__heading {
         line-height: 1.375;
-        margin-bottom: rem-spacing(40);
+        margin-bottom: rem-sizing(40);
 
         @include media-query('m') {
             line-height: 1.1667;
-            margin-bottom: rem-spacing(16);
+            margin-bottom: rem-sizing(16);
         }
     }
 
     &__kitemark {
-        margin-bottom: rem-spacing(16);
+        margin-bottom: rem-sizing(16);
 
         @include media-query('l') {
             text-align: right;
@@ -59,23 +59,23 @@
     &__accreditation-logo {
         // compensates for whitespace in logo
         position: relative;
-        right: rem-spacing(10);
+        right: rem-sizing(10);
 
         @include media-query('l') {
-            right: rem-spacing(-10);
+            right: rem-sizing(-10);
         }
     }
 
     &__summary {
-        margin-bottom: rem-spacing(16);
+        margin-bottom: rem-sizing(16);
 
         @include media-query('l') {
-            margin-bottom: rem-spacing(40);
+            margin-bottom: rem-sizing(40);
         }
     }
 
     &__releases {
-        row-gap: rem-spacing(8);
-        margin-bottom: rem-spacing(8);
+        row-gap: rem-sizing(8);
+        margin-bottom: rem-sizing(8);
     }
 }

--- a/ons_alpha/static_src/sass/components/_bulletin-header.scss
+++ b/ons_alpha/static_src/sass/components/_bulletin-header.scss
@@ -26,15 +26,19 @@
 
     &__doc-type {
         color: var(--ons-color-ocean-blue);
-        line-height: 1.38462;
+        line-height: 1.333;
         margin-bottom: 0;
+
+        @include media-query('m') {
+            line-height: 1.384;
+        }
     }
 
     &__heading {
         line-height: 1.375;
         margin-bottom: rem-spacing(40);
 
-        @include media-query('l') {
+        @include media-query('m') {
             line-height: 1.1667;
             margin-bottom: rem-spacing(16);
         }

--- a/ons_alpha/static_src/sass/components/_bulletin-header.scss
+++ b/ons_alpha/static_src/sass/components/_bulletin-header.scss
@@ -1,11 +1,13 @@
+@use 'config' as *;
+
 .bulletin-header {
     // this colour is in figma but not in the design system
     /* stylelint-disable */
     background-color: #efeff0;
     /* stylelint-enable */
     position: relative;
-    padding-bottom: 64px;
-    margin-bottom: 24px;
+    padding-bottom: rem-spacing(64);
+    margin-bottom: rem-spacing(24);
 
     &::before {
         position: absolute;
@@ -30,18 +32,18 @@
 
     &__heading {
         line-height: 1.375;
-        margin-bottom: 40px;
+        margin-bottom: rem-spacing(40);
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             line-height: 1.1667;
-            margin-bottom: 16px;
+            margin-bottom: rem-spacing(16);
         }
     }
 
     &__kitemark {
-        margin-bottom: 16px;
+        margin-bottom: rem-spacing(16);
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             text-align: right;
         }
     }
@@ -53,23 +55,23 @@
     &__accreditation-logo {
         // compensates for whitespace in logo
         position: relative;
-        right: 10px;
+        right: rem-spacing(10);
 
-        @media (min-width: 980px) {
-            right: -10px;
+        @include media-query('l') {
+            right: rem-spacing(-10);
         }
     }
 
     &__summary {
-        margin-bottom: 16px;
+        margin-bottom: rem-spacing(16);
 
-        @media screen and (min-width: 980px) {
-            margin-bottom: 40px;
+        @include media-query('l') {
+            margin-bottom: rem-spacing(40);
         }
     }
 
     &__releases {
-        row-gap: 8px;
-        margin-bottom: 8px;
+        row-gap: rem-spacing(8);
+        margin-bottom: rem-spacing(8);
     }
 }

--- a/ons_alpha/static_src/sass/components/_button-nav.scss
+++ b/ons_alpha/static_src/sass/components/_button-nav.scss
@@ -1,7 +1,7 @@
 @use 'config' as *;
 
 .button-nav {
-    padding: 0 rem-spacing(24);
+    padding: 0 rem-sizing(24);
     height: 67px;
     display: flex;
     align-items: center;

--- a/ons_alpha/static_src/sass/components/_button-nav.scss
+++ b/ons_alpha/static_src/sass/components/_button-nav.scss
@@ -1,10 +1,13 @@
 @use 'config' as *;
 
 .button-nav {
-    padding: rem-spacing(20) rem-spacing(24);
+    padding: 0 rem-spacing(24);
+    height: 67px;
+    display: flex;
+    align-items: center;
 
     @include media-query('l') {
-        padding: rem-spacing(24);
+        height: 72px;
     }
 
     &:focus {

--- a/ons_alpha/static_src/sass/components/_button-nav.scss
+++ b/ons_alpha/static_src/sass/components/_button-nav.scss
@@ -1,6 +1,11 @@
+@use 'config' as *;
+
 .button-nav {
-    padding: 0 24px;
-    height: 72px;
+    padding: rem-spacing(20) rem-spacing(24);
+
+    @include media-query('l') {
+        padding: rem-spacing(24);
+    }
 
     &:focus {
         background-color: var(--ons-color-focus);

--- a/ons_alpha/static_src/sass/components/_footer.scss
+++ b/ons_alpha/static_src/sass/components/_footer.scss
@@ -14,11 +14,11 @@
     }
 
     &__heading {
-        line-height: 1.777;
+        line-height: 1.333;
         margin-bottom: rem-spacing(8);
 
-        @include media-query('l') {
-            line-height: 2;
+        @include media-query('m') {
+            line-height: 1.385;
         }
     }
 
@@ -39,7 +39,8 @@
     }
 
     &__licence {
-        font-size: 1rem;
+        font-size: rem-spacing(18);
+        line-height: 1.555;
         display: flex;
         flex-direction: column;
         row-gap: rem-spacing(24);

--- a/ons_alpha/static_src/sass/components/_footer.scss
+++ b/ons_alpha/static_src/sass/components/_footer.scss
@@ -4,7 +4,7 @@
     &__body {
         background-color: var(--ons-color-grey-100);
         color: var(--ons-color-grey-5);
-        padding: rem-spacing(32) 0 rem-spacing(40);
+        padding: rem-sizing(32) 0 rem-sizing(40);
     }
 
     a,
@@ -15,7 +15,7 @@
 
     &__heading {
         line-height: 1.333;
-        margin-bottom: rem-spacing(8);
+        margin-bottom: rem-sizing(8);
 
         @include media-query('m') {
             line-height: 1.385;
@@ -24,27 +24,27 @@
 
     &__list {
         line-height: 1.555;
-        margin-bottom: rem-spacing(-8);
+        margin-bottom: rem-sizing(-8);
 
         li {
             margin-top: 0;
-            padding-bottom: rem-spacing(8);
+            padding-bottom: rem-sizing(8);
             margin-bottom: 0;
         }
     }
 
     &__hr {
-        margin-top: rem-spacing(40);
-        margin-bottom: rem-spacing(32);
+        margin-top: rem-sizing(40);
+        margin-bottom: rem-sizing(32);
     }
 
     &__licence {
-        font-size: rem-spacing(18);
+        font-size: rem-sizing(18);
         line-height: 1.555;
         display: flex;
         flex-direction: column;
-        row-gap: rem-spacing(24);
-        column-gap: rem-spacing(16);
+        row-gap: rem-sizing(24);
+        column-gap: rem-sizing(16);
         margin-bottom: 0;
 
         @include media-query('l') {

--- a/ons_alpha/static_src/sass/components/_footer.scss
+++ b/ons_alpha/static_src/sass/components/_footer.scss
@@ -1,8 +1,10 @@
+@use 'config' as *;
+
 .footer {
     &__body {
         background-color: var(--ons-color-grey-100);
         color: var(--ons-color-grey-5);
-        padding: 32px 0 40px;
+        padding: rem-spacing(32) 0 rem-spacing(40);
     }
 
     a,
@@ -13,38 +15,38 @@
 
     &__heading {
         line-height: 1.777;
-        margin-bottom: 8px;
+        margin-bottom: rem-spacing(8);
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             line-height: 2;
         }
     }
 
     &__list {
         line-height: 1.555;
-        margin-bottom: -8px;
+        margin-bottom: rem-spacing(-8);
 
         li {
             margin-top: 0;
-            padding-bottom: 8px;
+            padding-bottom: rem-spacing(8);
             margin-bottom: 0;
         }
     }
 
     &__hr {
-        margin-top: 40px;
-        margin-bottom: 32px;
+        margin-top: rem-spacing(40);
+        margin-bottom: rem-spacing(32);
     }
 
     &__licence {
         font-size: 1rem;
         display: flex;
         flex-direction: column;
-        row-gap: 24px;
-        column-gap: 16px;
+        row-gap: rem-spacing(24);
+        column-gap: rem-spacing(16);
         margin-bottom: 0;
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             flex-direction: row;
             align-items: center;
         }

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -46,9 +46,9 @@
 
     &__figure {
         // font-sizes don't match design system type scale in the figma file
-        font-size: 1.7rem;
+        font-size: rem-sizing(32);
         font-weight: 700;
-        line-height: 1.46;
+        line-height: 1.375;
         margin-bottom: 0;
 
         @include media-query('m') {

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -31,7 +31,7 @@
         line-height: 1.333;
         margin-bottom: rem-spacing(16);
 
-        @include media-query('l') {
+        @include media-query('m') {
             line-height: 1.385;
         }
     }
@@ -39,7 +39,7 @@
     &__title {
         line-height: 1.333;
 
-        @include media-query('l') {
+        @include media-query('m') {
             line-height: 1.385;
         }
     }
@@ -51,13 +51,13 @@
         line-height: 1.46;
         margin-bottom: 0;
 
-        @include media-query('l') {
-            margin-top: auto;
+        @include media-query('m') {
+            font-size: rem-spacing(36);
+            line-height: 1.333;
         }
 
         @include media-query('l') {
-            font-size: 2rem;
-            line-height: 1.27;
+            margin-top: auto;
         }
     }
 

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -1,21 +1,21 @@
 @use 'config' as *;
 
 .headline-figures {
-    padding-top: rem-spacing(24);
-    padding-bottom: rem-spacing(40);
+    padding-top: rem-sizing(24);
+    padding-bottom: rem-sizing(40);
 
     &__grid {
-        row-gap: rem-spacing(24);
+        row-gap: rem-sizing(24);
     }
 
     &__block {
         display: grid;
         grid-template-columns: 1fr 1fr;
         height: 100%;
-        column-gap: rem-spacing(40);
+        column-gap: rem-sizing(40);
         background-color: var(--ons-color-ocean-blue);
         color: var(--ons-color-white);
-        padding: rem-spacing(24);
+        padding: rem-sizing(24);
 
         @include media-query('s') {
             display: flex;
@@ -29,7 +29,7 @@
 
     &__heading {
         line-height: 1.333;
-        margin-bottom: rem-spacing(16);
+        margin-bottom: rem-sizing(16);
 
         @include media-query('m') {
             line-height: 1.385;
@@ -52,7 +52,7 @@
         margin-bottom: 0;
 
         @include media-query('m') {
-            font-size: rem-spacing(36);
+            font-size: rem-sizing(36);
             line-height: 1.333;
         }
 

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -1,21 +1,23 @@
+@use 'config' as *;
+
 .headline-figures {
-    padding-top: 24px;
-    padding-bottom: 40px;
+    padding-top: rem-spacing(24);
+    padding-bottom: rem-spacing(40);
 
     &__grid {
-        row-gap: 24px;
+        row-gap: rem-spacing(24);
     }
 
     &__block {
         display: grid;
         grid-template-columns: 1fr 1fr;
         height: 100%;
-        column-gap: 40px;
+        column-gap: rem-spacing(40);
         background-color: var(--ons-color-ocean-blue);
         color: var(--ons-color-white);
-        padding: 24px;
+        padding: rem-spacing(24);
 
-        @media (min-width: 500px) {
+        @include media-query('s') {
             display: flex;
             flex-direction: column;
         }
@@ -27,9 +29,9 @@
 
     &__heading {
         line-height: 1.333;
-        margin-bottom: 16px;
+        margin-bottom: rem-spacing(16);
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             line-height: 1.385;
         }
     }
@@ -37,7 +39,7 @@
     &__title {
         line-height: 1.333;
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             line-height: 1.385;
         }
     }
@@ -49,11 +51,11 @@
         line-height: 1.46;
         margin-bottom: 0;
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             margin-top: auto;
         }
 
-        @media (min-width: 980px) {
+        @include media-query('l') {
             font-size: 2rem;
             line-height: 1.27;
         }

--- a/ons_alpha/static_src/sass/components/_navigation.scss
+++ b/ons_alpha/static_src/sass/components/_navigation.scss
@@ -5,22 +5,22 @@
 .navigation {
     background-color: var(--ons-color-branded-tint);
     width: 100%;
-    margin-bottom: rem-spacing(16);
-    padding-top: rem-spacing(40);
+    margin-bottom: rem-sizing(16);
+    padding-top: rem-sizing(40);
 
     &__key-links {
         border-bottom: 1px solid var(--ons-color-ocean-blue);
-        row-gap: rem-spacing(16);
-        padding-bottom: rem-spacing(16);
-        margin-bottom: rem-spacing(20);
+        row-gap: rem-sizing(16);
+        padding-bottom: rem-sizing(16);
+        margin-bottom: rem-sizing(20);
 
         @include media-query('l') {
-            padding-bottom: rem-spacing(24);
+            padding-bottom: rem-sizing(24);
         }
     }
 
     &__child-list {
-        margin-bottom: rem-spacing(32);
+        margin-bottom: rem-sizing(32);
     }
 
     &__link {
@@ -42,7 +42,7 @@
     }
 
     &__heading {
-        margin-bottom: rem-spacing(16);
+        margin-bottom: rem-sizing(16);
 
         &--key-link {
             margin-bottom: 0;
@@ -50,7 +50,7 @@
     }
 
     &__paragraph {
-        margin-bottom: rem-spacing(8);
+        margin-bottom: rem-sizing(8);
 
         &--key-link {
             margin-bottom: 0;

--- a/ons_alpha/static_src/sass/components/_navigation.scss
+++ b/ons_alpha/static_src/sass/components/_navigation.scss
@@ -1,24 +1,26 @@
+@use 'config' as *;
+
 /* New navigation styling for November protoype */
 
 .navigation {
     background-color: var(--ons-color-branded-tint);
     width: 100%;
-    margin-bottom: 16px;
-    padding-top: 40px;
+    margin-bottom: rem-spacing(16);
+    padding-top: rem-spacing(40);
 
     &__key-links {
         border-bottom: 1px solid var(--ons-color-ocean-blue);
-        row-gap: 16px;
-        padding-bottom: 16px;
-        margin-bottom: 20px;
+        row-gap: rem-spacing(16);
+        padding-bottom: rem-spacing(16);
+        margin-bottom: rem-spacing(20);
 
-        @media (min-width: 980px) {
-            padding-bottom: 24px;
+        @include media-query('l') {
+            padding-bottom: rem-spacing(24);
         }
     }
 
     &__child-list {
-        margin-bottom: 32px;
+        margin-bottom: rem-spacing(32);
     }
 
     &__link {
@@ -40,7 +42,7 @@
     }
 
     &__heading {
-        margin-bottom: 16px;
+        margin-bottom: rem-spacing(16);
 
         &--key-link {
             margin-bottom: 0;
@@ -48,7 +50,7 @@
     }
 
     &__paragraph {
-        margin-bottom: 8px;
+        margin-bottom: rem-spacing(8);
 
         &--key-link {
             margin-bottom: 0;

--- a/ons_alpha/static_src/sass/components/_panel.scss
+++ b/ons_alpha/static_src/sass/components/_panel.scss
@@ -2,6 +2,6 @@
 
 .panel {
     @include media-query('l') {
-        padding: rem-spacing(24) rem-spacing(24) rem-spacing(24) rem-spacing(39);
+        padding: rem-sizing(24) rem-sizing(24) rem-sizing(24) rem-sizing(39);
     }
 }

--- a/ons_alpha/static_src/sass/components/_panel.scss
+++ b/ons_alpha/static_src/sass/components/_panel.scss
@@ -1,8 +1,9 @@
-.panel {
-    padding: 24px 24px 24px 39px;
+@use 'config' as *;
 
-    // full width at mobile, with no left hand border
-    @media (max-width: 979px) {
-        padding: 24px;
+.panel {
+    padding: rem-spacing(24);
+
+    @include media-query('l') {
+        padding: rem-spacing(24) rem-spacing(24) rem-spacing(24) rem-spacing(39);
     }
 }

--- a/ons_alpha/static_src/sass/components/_panel.scss
+++ b/ons_alpha/static_src/sass/components/_panel.scss
@@ -1,8 +1,6 @@
 @use 'config' as *;
 
 .panel {
-    padding: rem-spacing(24);
-
     @include media-query('l') {
         padding: rem-spacing(24) rem-spacing(24) rem-spacing(24) rem-spacing(39);
     }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
@@ -2,14 +2,14 @@
 
 // overrides to ons breadcrumb styles
 .ons-breadcrumbs {
-    padding: rem-spacing(16) 0;
+    padding: rem-sizing(16) 0;
 
     &__items {
-        margin-bottom: rem-spacing(-8);
+        margin-bottom: rem-sizing(-8);
     }
 
     &__item {
-        padding-bottom: rem-spacing(8);
+        padding-bottom: rem-sizing(8);
         line-height: 1.714;
     }
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
@@ -1,12 +1,14 @@
+@use 'config' as *;
+
 // overrides to ons breadcrumb styles
 .ons-breadcrumbs {
-    padding: 16px 0; // 16px not 1 rem (18px)
+    padding: rem-spacing(16) 0;
 
     &__items {
-        margin-bottom: -8px;
+        margin-bottom: rem-spacing(-8);
     }
 
     &__item {
-        padding-bottom: 8px;
+        padding-bottom: rem-spacing(8);
     }
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
@@ -10,5 +10,6 @@
 
     &__item {
         padding-bottom: rem-spacing(8);
+        line-height: 1.714;
     }
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_button.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_button.scss
@@ -12,8 +12,8 @@
         }
 
         .ons-icon {
-            width: rem-spacing(16);
-            height: rem-spacing(16);
+            width: rem-sizing(16);
+            height: rem-sizing(16);
             margin-top: 0;
         }
     }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_button.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_button.scss
@@ -1,7 +1,9 @@
+@use 'config' as *;
+
 // overrides the ons button styles
 .ons-btn {
     &--text-link {
-        @media (min-width: 980px) {
+        @include media-query('l') {
             display: inline-block;
         }
 
@@ -10,8 +12,8 @@
         }
 
         .ons-icon {
-            width: 16px;
-            height: 16px;
+            width: rem-spacing(16);
+            height: rem-spacing(16);
             margin-top: 0;
         }
     }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_container.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_container.scss
@@ -2,7 +2,7 @@
 
 // overrides to ons container styles
 .ons-container {
-    max-width: rem-spacing(
+    max-width: rem-sizing(
         1060
     ); // with 1rem padding either side, content is then 1024px wide to match the designs
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_container.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_container.scss
@@ -1,4 +1,8 @@
+@use 'config' as *;
+
 // overrides to ons container styles
 .ons-container {
-    max-width: 1060px; // with 1rem padding either side, content is then 1024px wide to match the designs
+    max-width: rem-spacing(
+        1060
+    ); // with 1rem padding either side, content is then 1024px wide to match the designs
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
@@ -3,40 +3,37 @@
 // addition to ons grid to use 'gap' to set widths between columns
 // Adds custom gap values to match the designs
 
-.ons-grid {
-    &--flex-gap {
-        display: flex;
-        flex-direction: column;
-        margin-left: 0;
-        flex-wrap: nowrap;
+.ons-grid-flex-gap {
+    display: flex;
+    flex-direction: column;
+    margin-left: 0;
+    flex-wrap: nowrap;
 
-        @include media-query('l') {
-            flex-direction: row;
-        }
+    @include media-query('l') {
+        flex-direction: row;
     }
 
-    // designed to be used with ons-grid--flex-gap
-    &--gap-40 {
+    &--40 {
         column-gap: rem-spacing(40);
     }
 
-    &--gap-32 {
+    &--32 {
         column-gap: rem-spacing(32);
     }
 
-    &--gap-24 {
+    &--24 {
         column-gap: rem-spacing(24);
     }
 }
 
 .ons-grid__col {
-    .ons-grid--flex-gap & {
+    .ons-grid-flex-gap & {
         padding-left: 0;
     }
 
     /* stylelint-disable selector-class-pattern */
     &--sticky\@m {
-        .ons-grid--flex-gap & {
+        .ons-grid-flex-gap & {
             align-self: flex-start;
         }
     }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
@@ -1,5 +1,7 @@
+@use 'config' as *;
+
 // addition to ons grid to use 'gap' to set widths between columns
-$grid-gutters: 1rem;
+// Adds custom gap values to match the designs
 
 .ons-grid {
     &--flex-gap {
@@ -8,23 +10,22 @@ $grid-gutters: 1rem;
         margin-left: 0;
         flex-wrap: nowrap;
 
-        // will need updating to fit correctly with the ons grid system
-        @media (min-width: 980px) {
+        @include media-query('l') {
             flex-direction: row;
         }
     }
 
     // designed to be used with ons-grid--flex-gap
     &--gap-40 {
-        column-gap: 40px;
+        column-gap: rem-spacing(40);
     }
 
     &--gap-32 {
-        column-gap: 32px;
+        column-gap: rem-spacing(32);
     }
 
     &--gap-24 {
-        column-gap: 24px;
+        column-gap: rem-spacing(24);
     }
 }
 

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
@@ -14,15 +14,15 @@
     }
 
     &--40 {
-        column-gap: rem-spacing(40);
+        column-gap: rem-sizing(40);
     }
 
     &--32 {
-        column-gap: rem-spacing(32);
+        column-gap: rem-sizing(32);
     }
 
     &--24 {
-        column-gap: rem-spacing(24);
+        column-gap: rem-sizing(24);
     }
 }
 

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_grid.scss
@@ -9,7 +9,7 @@
     margin-left: 0;
     flex-wrap: nowrap;
 
-    @include media-query('l') {
+    @include media-query('m') {
         flex-direction: row;
     }
 

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_header.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_header.scss
@@ -1,3 +1,5 @@
+@use 'config' as *;
+
 // overrides to ons header styles
 .ons-header {
     &__grid-top {
@@ -5,10 +7,10 @@
     }
 
     &__org-logo {
-        padding: 20px 0;
+        padding: rem-spacing(20) 0;
 
-        @media (min-width: 980px) {
-            padding: 24px 0;
+        @include media-query('l') {
+            padding: rem-spacing(24) 0;
         }
     }
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_header.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_header.scss
@@ -7,10 +7,10 @@
     }
 
     &__org-logo {
-        padding: rem-spacing(20) 0;
+        padding: rem-sizing(20) 0;
 
         @include media-query('l') {
-            padding: rem-spacing(24) 0;
+            padding: rem-sizing(24) 0;
         }
     }
 }

--- a/ons_alpha/static_src/sass/config.scss
+++ b/ons_alpha/static_src/sass/config.scss
@@ -1,0 +1,3 @@
+// Abstracts
+@forward 'config/functions';
+@forward 'config/mixins';

--- a/ons_alpha/static_src/sass/config/_functions.scss
+++ b/ons_alpha/static_src/sass/config/_functions.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-@function rem-spacing($pxValue) {
+@function rem-sizing($pxValue) {
     $remValue: math.div($pxValue, 16);
     @if $remValue == 0 {
         @return 0;

--- a/ons_alpha/static_src/sass/config/_functions.scss
+++ b/ons_alpha/static_src/sass/config/_functions.scss
@@ -1,0 +1,9 @@
+@use 'sass:math';
+
+@function rem-spacing($pxValue) {
+    $remValue: math.div($pxValue, 16);
+    @if $remValue == 0 {
+        @return 0;
+    }
+    @return $remValue * 1rem;
+}

--- a/ons_alpha/static_src/sass/config/_mixins.scss
+++ b/ons_alpha/static_src/sass/config/_mixins.scss
@@ -1,0 +1,19 @@
+@use 'sass:list';
+
+@use 'variables' as *;
+@use 'functions' as *;
+
+@mixin media-query($queries...) {
+    @each $query in $queries {
+        @each $breakpoint in $breakpoints {
+            $name: list.nth($breakpoint, 1);
+            $declaration: list.nth($breakpoint, 2);
+
+            @if $query == $name and $declaration {
+                @media only screen and #{$declaration} {
+                    @content;
+                }
+            }
+        }
+    }
+}

--- a/ons_alpha/static_src/sass/config/_variables.scss
+++ b/ons_alpha/static_src/sass/config/_variables.scss
@@ -1,0 +1,10 @@
+// Based on https://github.com/ONSdigital/design-system/blob/d3c30b9400c9f0bdfca21f838d82b8890bd1ec05/migration_guides/70.x.x-to-72.0.0-migration-guide.md?plain=1#L196
+$breakpoints: (
+    '2xs' '(min-width: 300px)',
+    'xs' '(min-width: 400px)',
+    's' '(min-width: 500px)',
+    'm' '(min-width: 740px)',
+    'l' '(min-width: 980px)',
+    'xl' '(min-width: 1300px)',
+    '2xl' '(min-width: 1600px)'
+);


### PR DESCRIPTION
### What is the context of this PR?
With the major design system release, quite a few styling changes are needed:

- Updates to the header and footer templates to class names and variable names
- Add the logo at the bottom of the footer, as per the updated template (but wrap in an if block so it doesn't display in our version)
- Add a media query mixin to match the sizes used for ons, to make media query use more consistent
- Add a function to work out rem-spacing based on a base 16 size
- Update the `ons-grid--flex-grid` classname to be a top level block (like how `ons-grid-flex` has changed in the design system)
- Update font-sizes and line-heights now we are using base 16
- A few fixes to styles I spotted whilst doing these changes


Note that I also need to update the document block styling but that isn't merged yet, so I'll do it in a separate pull request.


### How to review
All the changes can be tested on a bulletin page. It might help to look at the code changes commit by commit.

This may be helpful when reviewing: https://github.com/ONSdigital/design-system/blob/d3c30b9400c9f0bdfca21f838d82b8890bd1ec05/migration_guides/70.x.x-to-72.0.0-migration-guide.md?plain=1#L196
