### PR TITLE
Styling for rich text, page layout and table of contents

### DIFF
--- a/ons_alpha/bulletins/models.py
+++ b/ons_alpha/bulletins/models.py
@@ -75,12 +75,12 @@ class BulletinPage(BundledPageMixin, RoutablePageMixin, BasePage):
                         "is_accredited",
                         help_text="If ticked, will show the official statistics accredited logo.",
                     ),
-                    FieldPanel("contact_details"),
                 ],
                 heading="Metadata",
             ),
             FieldPanel("headline_figures"),
             FieldPanel("body"),
+            FieldPanel("contact_details"),
         ]
     )
 
@@ -124,7 +124,7 @@ class BulletinPage(BundledPageMixin, RoutablePageMixin, BasePage):
 
     @cached_property
     def toc(self):
-        items = [{"url": "#summary", "text": "Summary"}]
+        items = []
         for block in self.body:  # pylint: disable=not-an-iterable,useless-suppression
             if hasattr(block.block, "to_table_of_contents_items"):
                 items += block.block.to_table_of_contents_items(block.value)

--- a/ons_alpha/core/blocks/stream_blocks.py
+++ b/ons_alpha/core/blocks/stream_blocks.py
@@ -40,6 +40,7 @@ class CoreStoryBlock(StreamBlock):
 
     class Meta:
         block_counts = {"related_links": {"max_num": 1}}
+        template = "templates/components/streamfield/stream_block.html"
 
 
 class CorrectionsNoticesStoryBlock(StreamBlock):

--- a/ons_alpha/jinja2/templates/components/streamfield/heading_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/heading_block.html
@@ -1,3 +1,3 @@
 {% if show_back_to_toc %}<a href="#toc">Back to table of contents</a>{% endif %}
 
-<h2 id="{{ value|slugify }}">{{ value }}</h2>
+<h2 id="{{ value|slugify }}" class="heading-2">{{ value }}</h2>

--- a/ons_alpha/jinja2/templates/components/streamfield/stream_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/stream_block.html
@@ -1,3 +1,10 @@
-{% for block in value %}
-    {% include_block block %}
+{% for content_block in value %}
+    {% with block_id = content_block.id %}
+        <div class="
+                    {% if content_block.block_type !='heading' %}streamfield{% endif %}
+                    {% if last_flush %}streamfield--last-flush{% endif %}
+                   ">
+            {% include_block content_block %}
+        </div>
+    {% endwith %}
 {% endfor %}

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -88,7 +88,7 @@
                 {# fmt:off #}
                 {{-
                     onsTableOfContents({
-                        "title": 'Table of contents',
+                        "title": 'Contents',
                         "ariaLabel": 'Sections in this page',
                         "itemsList": toc
                     })
@@ -107,15 +107,19 @@
                     </div>
                 {% endif %}
 
-                {% for content_block in page.body %}
-                    {% with block_id = content_block.id %}
-                        {% include_block content_block %}
-                    {% endwith %}
-                {% endfor %}
+                {# if there are no contact details on the page, we don't want the last
+                streamfield block to have a bottom margin. last_flush is used in stream_block.html #}
+                {% if page.contact_details %}
+                    {% set last_flush = False %}
+                {% else %}
+                    {% set last_flush = True %}
+                {% endif %}
+
+                {% include_block page.body %}
 
                 {% if page.contact_details %}
                     <section id="contact-details">
-                        <h2 class="contact-details__heading">{{ _("Contact details") }}</h2>
+                        <h2 class="heading-2">{{ _("Contact details") }}</h2>
 
                         {% set contactDetailsMarkup %}
                             <p class="contact-details__line">

--- a/ons_alpha/jinja2/templates/pages/methodology_page.html
+++ b/ons_alpha/jinja2/templates/pages/methodology_page.html
@@ -23,7 +23,7 @@
             {# fmt:off #}
             {{-
                 onsTableOfContents({
-                    "title": 'Table of contents',
+                    "title": 'Contents',
                     "ariaLabel": 'Sections in this page',
                     "itemsList": toc
                 })
@@ -74,11 +74,7 @@
                         </section>
                     {% endif %}
 
-                    {% for content_block in page.body %}
-                        {% with block_id = content_block.id %}
-                            {% include_block content_block %}
-                        {% endwith %}
-                    {% endfor %}
+                    {% include_block page.body %}
 
                     {% if page.contact_details %}
                         <section id="contact-details">

--- a/ons_alpha/jinja2/templates/pages/topics/topic_page.html
+++ b/ons_alpha/jinja2/templates/pages/topics/topic_page.html
@@ -21,7 +21,7 @@
                 {# fmt:off #}
                 {{-
                     onsTableOfContents({
-                        "title": 'Table of contents',
+                        "title": 'Contents',
                         "ariaLabel": 'Sections in this page',
                         "itemsList": page.toc
                     })
@@ -31,11 +31,7 @@
 
             <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
                 {% if page.body %}
-                    {% for content_block in page.body %}
-                        {% with block_id = content_block.id %}
-                            {% include_block content_block %}
-                        {% endwith %}
-                    {% endfor %}
+                    {% include_block page.body %}
                 {% else %}
                     {% if page.sections %}
                         {# fmt:off #}

--- a/ons_alpha/static_src/sass/base/_typography.scss
+++ b/ons_alpha/static_src/sass/base/_typography.scss
@@ -1,0 +1,6 @@
+@use 'config' as *;
+
+// Create a re-usable class for our custom heading 2 style
+.heading-2 {
+    @include heading-2();
+}

--- a/ons_alpha/static_src/sass/components/_contact-details.scss
+++ b/ons_alpha/static_src/sass/components/_contact-details.scss
@@ -1,11 +1,6 @@
 @use 'config' as *;
 
 .contact-details {
-    &__heading {
-        font-size: rem-sizing(26);
-        line-height: 1.385;
-    }
-
     &__line {
         margin-bottom: 0;
     }

--- a/ons_alpha/static_src/sass/components/_document-list-block.scss
+++ b/ons_alpha/static_src/sass/components/_document-list-block.scss
@@ -4,9 +4,6 @@
     margin-bottom: rem-spacing(64);
 
     &__title {
-        margin-bottom: rem-sizing(16);
-        // font-sizes don't match design system type scale in the figma file
-        font-size: rem-sizing(26);
-        line-height: 1.385;
+        @include heading-2();
     }
 }

--- a/ons_alpha/static_src/sass/components/_streamfield.scss
+++ b/ons_alpha/static_src/sass/components/_streamfield.scss
@@ -1,0 +1,11 @@
+@use 'config' as *;
+
+.streamfield {
+    margin-bottom: rem-sizing(64);
+
+    &--last-flush {
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_page.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_page.scss
@@ -1,0 +1,8 @@
+@use 'config' as *;
+
+// overrides to ons page styles - to be discussed if these should be merged back to the design system
+.ons-page {
+    &__main {
+        margin-bottom: rem-sizing(80);
+    }
+}

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_toc.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_toc.scss
@@ -1,0 +1,9 @@
+@use 'config' as *;
+
+// overrides to ons table of contents styles - to be discussed if these should be merged back to the design system
+.ons-toc {
+    &-container {
+        border-bottom: 4px solid var(--ons-color-ocean-blue);
+        margin-bottom: rem-sizing(40);
+    }
+}

--- a/ons_alpha/static_src/sass/config/_mixins.scss
+++ b/ons_alpha/static_src/sass/config/_mixins.scss
@@ -17,3 +17,11 @@
         }
     }
 }
+
+// The font-size and line height for heading twos in the design system don't match the prototype figma file
+// where the font-size is 26px at mobile as well as at desktop
+@mixin heading-2 {
+    font-size: rem-sizing(26);
+    line-height: 1.385;
+    margin-bottom: rem-sizing(16);
+}

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -1,3 +1,6 @@
+// Base
+@use 'base/typography';
+
 // New components created for the prototype
 @use 'components/bulletin-header';
 @use 'components/button-nav';
@@ -7,6 +10,7 @@
 @use 'components/headline-figures';
 @use 'components/navigation';
 @use 'components/panel';
+@use 'components/streamfield';
 
 // ONS design system overrides
 @use 'components/design_system_overrides/breadcrumbs';
@@ -15,4 +19,6 @@
 @use 'components/design_system_overrides/document-list';
 @use 'components/design_system_overrides/grid';
 @use 'components/design_system_overrides/header';
+@use 'components/design_system_overrides/page';
 @use 'components/design_system_overrides/text-indent';
+@use 'components/design_system_overrides/toc';


### PR DESCRIPTION
### What is the context of this PR?
- Adds styling for headings and rich text (actually the rich text has no changes needed)
- Adds spacing between streamfield blocks (and makes use of a reusable stream block template instead of repeating the code in each template)
- Amends spacing between page and footer (overriding design system)
- Amends styling of table of contents (overriding design system)
- Update 'table of contents' heading to 'contents' (to match figma design)
- Remove 'summary' from table of contents - can be created with a section heading block and a rich text block
- Move table of contents below the body when editing a bulletin page, so it matches where this appears on the published page

### How to review
Edit and preview a bulletin page on your local build and compare to the figma designs

### Screenshots

<details>
<summary>Screenshots in here</summary>

**Desktop**
![screencapture-localhost-8000-topic-section-topic-page-bulletin-series-bulletin-page-2024-10-15-14_58_08](https://github.com/user-attachments/assets/acb4d26b-1e43-44f8-a895-b2cb1a914687)


**Mobile**
![screencapture-localhost-8000-topic-section-topic-page-bulletin-series-bulletin-page-2024-10-15-14_58_27](https://github.com/user-attachments/assets/b1dfdd8e-882f-4b0c-8e73-9c98bc2f6d75)


</details>

