### PR TITLE
Chart embed styling

### DIFF
--- a/ons_alpha/jinja2/templates/components/streamfield/ons_embed_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/ons_embed_block.html
@@ -1,4 +1,9 @@
-<div class="ons-u-mb-s">
+{# This is used to embed charts. If we want to use it for other embeds like video
+in the future we might need a separate block for those.
+pym.js handles the responsive aspect ratio for the iframe. #}
+
+<h3 class="heading-3 chart-embed__heading">{{ value.title }}</h3>
+<div class="chart-embed">
     <div class="pym-interactive"
          id="{{ block_id }}"
          data-url="{{ value.url }}"

--- a/ons_alpha/static_src/sass/base/_typography.scss
+++ b/ons_alpha/static_src/sass/base/_typography.scss
@@ -4,3 +4,8 @@
 .heading-2 {
     @include heading-2();
 }
+
+// Ditto for heading 3
+.heading-3 {
+    @include heading-3();
+}

--- a/ons_alpha/static_src/sass/components/_chart-embed.scss
+++ b/ons_alpha/static_src/sass/components/_chart-embed.scss
@@ -1,0 +1,11 @@
+@use 'config' as *;
+
+.chart-embed {
+    padding: rem-sizing(24) 0;
+    border-top: 1px solid var(--ons-color-grey-75);
+    border-bottom: 1px solid var(--ons-color-grey-75);
+
+    &__heading {
+        margin-bottom: rem-sizing(32);
+    }
+}

--- a/ons_alpha/static_src/sass/components/_rich-text.scss
+++ b/ons_alpha/static_src/sass/components/_rich-text.scss
@@ -1,0 +1,7 @@
+@use 'config' as *;
+
+.rich-text {
+    h3 {
+        @include heading-3();
+    }
+}

--- a/ons_alpha/static_src/sass/config/_mixins.scss
+++ b/ons_alpha/static_src/sass/config/_mixins.scss
@@ -25,3 +25,10 @@
     line-height: 1.385;
     margin-bottom: rem-sizing(16);
 }
+
+// Ditto for heading 3s which have a different font-size and line height at mobile
+
+@mixin heading-3 {
+    font-size: rem-sizing(22);
+    line-height: 1.455;
+}

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -5,11 +5,13 @@
 @use 'components/bulletin-header';
 @use 'components/button-nav';
 @use 'components/document-list-block';
+@use 'components/chart-embed';
 @use 'components/contact-details';
 @use 'components/footer';
 @use 'components/headline-figures';
 @use 'components/navigation';
 @use 'components/panel';
+@use 'components/rich-text';
 @use 'components/streamfield';
 
 // ONS design system overrides


### PR DESCRIPTION
### What is the context of this PR?
- Adds styling for chart embeds - spacing and borders
- Updates heading 3 styling across the board as the mobile size doesn't match the design system (this was missed from the previous rich text merge request)

### How to review
Embed some charts in a bulletin page, for example 

https://www.ons.gov.uk/visualisations/dvc1795/diagram2
https://www.ons.gov.uk/visualisations/dvc1795/diagram1

Use the 'embed' block rather than the 'chart' block.

Note highcharts embeds won't currently work.

### Screenshots

<details>
<summary>
Expand to see screenshots
</summary>

**Desktop**

![Screenshot 2024-10-16 at 12 07 08](https://github.com/user-attachments/assets/63c76d71-ac92-4208-bffb-3bf7b0ce64cb)

**Mobile**
![Screenshot 2024-10-16 at 12 07 24](https://github.com/user-attachments/assets/b382c4f8-08be-4622-9e15-eda805a9fe16)


</details>