### PR TITLE
Styling for the topic page

### DIFF
--- a/ons_alpha/core/blocks/featured_document.py
+++ b/ons_alpha/core/blocks/featured_document.py
@@ -1,11 +1,6 @@
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
-from wagtail.blocks import (
-    ChoiceBlock,
-    PageChooserBlock,
-    RichTextBlock,
-    StructBlock,
-)
+from wagtail.blocks import ChoiceBlock, PageChooserBlock, RichTextBlock, StructBlock
 
 from ons_alpha.core.constants import CONTENT_TYPE_LABEL_CHOICES
 
@@ -33,13 +28,14 @@ class FeaturedDocumentBlock(StructBlock):
         # Prepare 'document' object for the context
         page = value["page"].specific
         document = {
-            "title": page.title,
+            "title": {
+                "text": page.title,
+                "url": page.get_url(parent_context.get("request") if parent_context else None),
+            },
             "featured": True,
-            "showMetadataFirst": True,
             "description": value["description"],
-            "url": page.get_url(parent_context.get("request") if parent_context else None),
             "metadata": {
-                "type": {"text": value["content_type_label"]},
+                "object": {"text": value["content_type_label"]},
             },
         }
         if release_date := getattr(page, "release_date", None):

--- a/ons_alpha/jinja2/templates/components/streamfield/featured_document_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/featured_document_block.html
@@ -1,12 +1,14 @@
-{% from "components/document-list/_macro.njk" import onsDocumentList %}
+{# Note: this is not actually a document - but it uses the design system document list component for styling #}
+{% from "component_overrides/document-list/_macro.njk" import onsDocumentListNew %}
 
-<section id="{{ slug }}">
-    <h2 >{{ heading }}</h2>
+<section id="{{ slug }}" class="document-list-block">
+    <h2 class="heading-2">{{ heading }}</h2>
 
     {# fmt:off #}
     {{-
-        onsDocumentList({
+        onsDocumentListNew({
             "documents": documents,
+            "headingLevel": 3,
         })
     }}
     {# fmt:on #}

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -6,71 +6,69 @@
 
 {% block header_area %}
     <div class="bulletin-header">
-        <div class="bulletin-header__content">
-            <div class="ons-container">
-                {% include "templates/components/navigation/breadcrumbs.html" %}
-                <p class="ons-u-fs-l bulletin-header__doc-type">{{ page.document_type|default("Analysis") }}</p>
+        <div class="ons-container">
+            {% include "templates/components/navigation/breadcrumbs.html" %}
+            <p class="bulletin-header__doc-type">{{ page.document_type|default("Analysis") }}</p>
 
-                <div class="ons-grid ons-grid-flex-gap">
-                    <div class="ons-grid__col ons-col-10@m ">
-                        <h1 class="ons-u-fs-3xl bulletin-header__heading">
-                            {{ page.full_title }}
-                        </h1>
+            <div class="ons-grid ons-grid-flex-gap">
+                <div class="ons-grid__col ons-col-10@m ">
+                    <h1 class="ons-u-fs-3xl bulletin-header__heading">
+                        {{ page.full_title }}
+                    </h1>
+                </div>
+                <div class="ons-grid__col ons-col-2@m bulletin-header__kitemark">
+                    {% if page.is_accredited %}
+                        <a href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/" class="bulletin-header__accreditation-link">
+                            <img src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/v2/uksa-kitemark-en.svg" alt="UK Statistics Authority Kitemark" class="bulletin-header__accreditation-logo" width="90">
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <div class="ons-container">
+            <p class="bulletin-header__summary">{{ page.summary }}</p>
+        </div>
+
+        {% block release_meta %}
+            <div class="ons-container">
+                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
+                    <div class="ons-grid__col ons-col-4@m">
+                        <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
+                        <span class="ons-u-nowrap">{{ page.release_date|date("j F Y") }}</span>
                     </div>
-                    <div class="ons-grid__col ons-col-2@m bulletin-header__kitemark">
-                        {% if page.is_accredited %}
-                            <a href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/" class="bulletin-header__accreditation-link">
-                                <img src="https://cdn.ons.gov.uk/assets/images/ons-logo/kitemark/v2/uksa-kitemark-en.svg" alt="UK Statistics Authority Kitemark" class="bulletin-header__accreditation-logo" width="90">
-                            </a>
+                    <div class="ons-grid__col ons-col-4@m">
+                        <span class="ons-u-fs-r--b">{{ _("Version") }}:</span>
+                        {% if latest_version_url %}
+                            <span>{{ _("This has been superseded.") }} <a href="{{ latest_version_url }}">{{ _("View corrected version") }}</a></span>
+                        {% else %}
+                            <span class="ons-u-nowrap">{{ _("Latest") }}</span>
                         {% endif %}
                     </div>
-                </div>
-            </div>
-
-            <div class="ons-container">
-                <p class="bulletin-header__summary">{{ page.summary }}</p>
-            </div>
-
-            {% block release_meta %}
-                <div class="ons-container">
-                    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
-                        <div class="ons-grid__col ons-col-4@m">
-                            <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
-                            <span class="ons-u-nowrap">{{ page.release_date|date("j F Y") }}</span>
-                        </div>
-                        <div class="ons-grid__col ons-col-4@m">
-                            <span class="ons-u-fs-r--b">{{ _("Version") }}:</span>
-                            {% if latest_version_url %}
-                                <span>{{ _("This has been superseded.") }} <a href="{{ latest_version_url }}">{{ _("View corrected version") }}</a></span>
-                            {% else %}
-                                <span class="ons-u-nowrap">{{ _("Latest") }}</span>
-                            {% endif %}
-                        </div>
-                        <div class="ons-grid__col ons-col-4@m">
-                            <span class="ons-u-fs-r--b">{{ _("Contact") }}:</span>
-                            <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
-                        </div>
-                    </div>
-                    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
-                        <div class="ons-grid__col ons-col-4@m">
-                            {% if page.next_release_date %}
-                                <span class="ons-u-fs-r--b">{{ _("Next release") }}:</span>
-                                <span class="ons-u-nowrap">{{ page.next_release_date|date("j F Y") }}</span>
-                            {% endif %}
-                        </div>
-                        <div class="ons-grid__col ons-col-4@m">
-                            <span class="ons-u-fs-r--b">{{ _("Releases") }}:</span>
-                            {% if page.is_latest %}
-                                <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
-                            {% else %}
-                                <a href="{{  routablepageurl(page.get_parent().specific, "latest_release") }}">{{ _("View latest release") }}</a>
-                            {% endif %}
-                        </div>
-                        <div class="ons-grid__col ons-col-4@m"></div>
+                    <div class="ons-grid__col ons-col-4@m">
+                        <span class="ons-u-fs-r--b">{{ _("Contact") }}:</span>
+                        <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
                     </div>
                 </div>
-            {% endblock %}
-        </div>
+                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
+                    <div class="ons-grid__col ons-col-4@m">
+                        {% if page.next_release_date %}
+                            <span class="ons-u-fs-r--b">{{ _("Next release") }}:</span>
+                            <span class="ons-u-nowrap">{{ page.next_release_date|date("j F Y") }}</span>
+                        {% endif %}
+                    </div>
+                    <div class="ons-grid__col ons-col-4@m">
+                        <span class="ons-u-fs-r--b">{{ _("Releases") }}:</span>
+                        {% if page.is_latest %}
+                            <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
+                        {% else %}
+                            <a href="{{  routablepageurl(page.get_parent().specific, "latest_release") }}">{{ _("View latest release") }}</a>
+                        {% endif %}
+                    </div>
+                    <div class="ons-grid__col ons-col-4@m"></div>
+                </div>
+            </div>
+        {% endblock %}
     </div>
 
     {% if page.headline_figures %}

--- a/ons_alpha/jinja2/templates/pages/topics/topic_page.html
+++ b/ons_alpha/jinja2/templates/pages/topics/topic_page.html
@@ -4,98 +4,121 @@
 {% from "components/related-content/_macro.njk" import onsRelatedContent %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 
-{% block main %}
-    <h1>{{ page.title }}</h1>
+{% block header_area %}
+    <div class="topic-header">
+        <div class="topic-header__circles" aria-hidden="true">
+            <div class="topic-header__circle-one"></div>
+            <div class="topic-header__circle-two"></div>
+            <div class="topic-header__circle-three"></div>
+        </div>
+        <div class="ons-container">
+            {% include "templates/components/navigation/breadcrumbs.html" %}
+            <p class="topic-header__doc-type">Topic</p>
 
-    {% if page.summary %}
-        <p>{{ page.summary }}</p>
-    {% endif %}
+            <div class="ons-grid">
+                <div class="ons-grid__col ons-col-8@m ">
+                    <h1 class="ons-u-fs-3xl topic-header__heading">
+                        {{ page.title }}
+                    </h1>
+                    <p class="topic-header__summary">{{ page.summary }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
 
     {% if page.headline_figures %}
         {% include_block page.headline_figures %}
     {% endif %}
 
+    {{ super() }}
+
+{% endblock %}
+
+{% block main %}
+
     {% if page.toc %}
-        <div class="ons-grid ons-js-toc-container ons-u-ml-no ons-u-mt-s">
-            <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-u-p-no">
-                {# fmt:off #}
-                {{-
-                    onsTableOfContents({
-                        "title": 'Contents',
-                        "ariaLabel": 'Sections in this page',
-                        "itemsList": page.toc
-                    })
-                }}
-                {# fmt:on #}
-            </div>
+        <div class="ons-container">
+            <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
+                <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
+                    {# fmt:off #}
+                    {{-
+                        onsTableOfContents({
+                            "title": 'Contents',
+                            "ariaLabel": 'Sections in this page',
+                            "itemsList": page.toc
+                        })
+                    }}
+                    {# fmt:on #}
+                </div>
 
-            <div class="ons-grid__col ons-col-8@m ons-col-12@s ons-u-p-no@xxs@m">
-                {% if page.body %}
-                    {% include_block page.body %}
-                {% else %}
-                    {% if page.sections %}
-                        {# fmt:off #}
-                        {{-
-                            onsPanel({
-                                "body": '<p>Currently we show the latest bulletin and articles per series, and the last five methodology pages ordered by the last review date</p>'
-                            })
-                        }}
-                        {# fmt:on #}
-                        <br />
-
-                        {% for section_title, section_items in page.sections.items() %}
-                            <section id="{{ section_title|slugify() }}">
-                                <h2>{{ section_title }}</h2>
-
-                                <div class="ons-timeline">{# done as markup as onsTimeline() errors even with the example in the DS #}
-                                    {% for item in section_items %}
-                                        <div class="ons-timeline__item">
-                                            <h2 class="ons-timeline__heading">
-                                                <a href="{{ pageurl(item) }}">{{ item.full_title or item.title }}</a>
-                                            </h2>
-                                            <div class="ons-timeline__content">
-                                                <p>{{ item.summary }}</p>
-                                            </div>
-                                        </div>
-                                    {% endfor %}
-                                </div>
-                            </section>
-                        {% endfor %}
-                    {% endif %}
-
-                    {% if page.related_by_topic %}
-                        <section id="related">
-                            <h2>{{ _("Related content") }}</h2>
-                            <p>{% trans topic=page.topic %}This sections surfaces content tagged with "{{ topic }}"{% endtrans %}</p>
-
-                            {% set rows=[] %}
-                            {% for type, items in page.related_by_topic.items() %}
-                                {% set items_list=[] %}
-                                {% for item in items %}
-                                    {% do items_list.append({"url": pageurl(item), "text": item.full_title or item.title}) %}
-                                {% endfor %}
-                                {# fmt:off #}
-                                {%
-                                    do rows.append({
-                                        "id": "related-content-" + type|slugify(),
-                                        "title": type,
-                                        "itemsList": items_list
-                                    })
-                                %}
-                                {# fmt:on #}
-                            {% endfor %}
-
+                <div class="ons-grid__col ons-col-8@m">
+                    {% if page.body %}
+                        {% include_block page.body %}
+                    {% else %}
+                        {% if page.sections %}
                             {# fmt:off #}
-                            {{
-                                onsRelatedContent({
-                                    "ariaLabel": 'Related content',
-                                    "rows": rows
+                            {{-
+                                onsPanel({
+                                    "body": '<p>Currently we show the latest bulletin and articles per series, and the last five methodology pages ordered by the last review date</p>'
                                 })
                             }}
                             {# fmt:on #}
-                        </section>
+                            <br />
+
+                            {% for section_title, section_items in page.sections.items() %}
+                                <section id="{{ section_title|slugify() }}">
+                                    <h2>{{ section_title }}</h2>
+
+                                    <div class="ons-timeline">{# done as markup as onsTimeline() errors even with the example in the DS #}
+                                        {% for item in section_items %}
+                                            <div class="ons-timeline__item">
+                                                <h2 class="ons-timeline__heading">
+                                                    <a href="{{ pageurl(item) }}">{{ item.full_title or item.title }}</a>
+                                                </h2>
+                                                <div class="ons-timeline__content">
+                                                    <p>{{ item.summary }}</p>
+                                                </div>
+                                            </div>
+                                        {% endfor %}
+                                    </div>
+                                </section>
+                            {% endfor %}
+                        {% endif %}
+
+                        {% if page.related_by_topic %}
+                            <section id="related">
+                                <h2>{{ _("Related content") }}</h2>
+                                <p>{% trans topic=page.topic %}This sections surfaces content tagged with "{{ topic }}"{% endtrans %}</p>
+
+                                {% set rows=[] %}
+                                {% for type, items in page.related_by_topic.items() %}
+                                    {% set items_list=[] %}
+                                    {% for item in items %}
+                                        {% do items_list.append({"url": pageurl(item), "text": item.full_title or item.title}) %}
+                                    {% endfor %}
+                                    {# fmt:off #}
+                                    {%
+                                        do rows.append({
+                                            "id": "related-content-" + type|slugify(),
+                                            "title": type,
+                                            "itemsList": items_list
+                                        })
+                                    %}
+                                    {# fmt:on #}
+                                {% endfor %}
+
+                                {# fmt:off #}
+                                {{
+                                    onsRelatedContent({
+                                        "ariaLabel": 'Related content',
+                                        "rows": rows
+                                    })
+                                }}
+                                {# fmt:on #}
+                            </section>
+                        {% endif %}
                     {% endif %}
-                {% endif %}
+                </div>
             </div>
         </div>
     {% endif %}

--- a/ons_alpha/static_src/sass/components/_bulletin-header.scss
+++ b/ons_alpha/static_src/sass/components/_bulletin-header.scss
@@ -2,12 +2,14 @@
 
 .bulletin-header {
     // this colour is in figma but not in the design system
-    /* stylelint-disable */
-    background-color: #efeff0;
-    /* stylelint-enable */
+    background-color: $color--pale-grey;
     position: relative;
     padding-bottom: rem-sizing(64);
     margin-bottom: rem-sizing(24);
+
+    @include media-query('m') {
+        margin-bottom: rem-sizing(40);
+    }
 
     &::before {
         position: absolute;
@@ -18,18 +20,23 @@
         border-radius: 0 0 50% 50%;
         background-color: var(--ons-color-grey-5);
         content: '';
-    }
 
-    &__content {
-        position: relative;
+        @include media-query('l') {
+            border-radius: 0 0 80% 50%;
+            left: -25%;
+            width: 130%;
+        }
     }
 
     &__doc-type {
-        color: var(--ons-color-ocean-blue);
+        font-size: rem-sizing(24);
         line-height: 1.333;
+        font-weight: 700;
+        color: var(--ons-color-ocean-blue);
         margin-bottom: 0;
 
         @include media-query('m') {
+            font-size: rem-sizing(26);
             line-height: 1.384;
         }
     }

--- a/ons_alpha/static_src/sass/components/_document-list-block.scss
+++ b/ons_alpha/static_src/sass/components/_document-list-block.scss
@@ -1,7 +1,7 @@
 @use 'config' as *;
 
 .document-list-block {
-    margin-bottom: rem-spacing(64);
+    margin-bottom: rem-sizing(64);
 
     &__title {
         @include heading-2();

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -1,7 +1,7 @@
 @use 'config' as *;
 
 .headline-figures {
-    padding-top: rem-sizing(24);
+    //padding-top: rem-sizing(24);
     padding-bottom: rem-sizing(40);
 
     &__grid {

--- a/ons_alpha/static_src/sass/components/_rich-text.scss
+++ b/ons_alpha/static_src/sass/components/_rich-text.scss
@@ -4,4 +4,12 @@
     h3 {
         @include heading-3();
     }
+
+    // In the document block list styling from ONS, we don't want list items inside rich-text to have circle styling
+
+    .ons-document-list & {
+        ul {
+            list-style-type: disc;
+        }
+    }
 }

--- a/ons_alpha/static_src/sass/components/_topic-header.scss
+++ b/ons_alpha/static_src/sass/components/_topic-header.scss
@@ -1,0 +1,114 @@
+@use 'config' as *;
+
+.topic-header {
+    // this colour is in figma but not in the design system
+    background-color: $color--grey-blue;
+    position: relative;
+    padding-bottom: rem-sizing(64);
+    margin-bottom: rem-sizing(40);
+    overflow: hidden;
+
+    &::before {
+        position: absolute;
+        inset: 0;
+        width: 150%;
+        height: 100%;
+        left: -40%;
+        border-radius: 0 0 50% 50%;
+        // this colour is in figma but not in the design system
+        background-color: $color--pale-blue;
+        content: '';
+
+        @include media-query('l') {
+            border-radius: 0 0 80% 50%;
+            left: -25%;
+            width: 130%;
+        }
+    }
+
+    &__circle-one {
+        @include media-query('l') {
+            position: absolute;
+            width: 440px;
+            height: 440px;
+            // this colour is in figma but not in the design system
+            background-color: $color--grey-blue;
+            border-radius: 50%;
+            top: -339px;
+            right: 59px;
+        }
+    }
+
+    &__circle-two {
+        position: absolute;
+        width: 40px;
+        height: 40px;
+        // this colour is in figma but not in the design system
+        background-color: $color--buff;
+        border-radius: 50%;
+        // these are relative to the 'before' styled curve
+        bottom: 7%;
+        right: 15%;
+
+        @include media-query('l') {
+            width: 72px;
+            height: 72px;
+            bottom: 30%;
+            right: 25%;
+        }
+
+        @include media-query('xl') {
+            right: 346px;
+        }
+    }
+
+    &__circle-three {
+        position: absolute;
+        width: 80px;
+        height: 80px;
+        background-color: var(--ons-color-ocean-blue);
+        border-radius: 50%;
+        bottom: 10%;
+        right: -26px;
+
+        @include media-query('l') {
+            width: 156px;
+            height: 156px;
+            right: 2%;
+        }
+
+        @include media-query('xl') {
+            right: 43px;
+        }
+    }
+
+    &__doc-type {
+        font-size: rem-sizing(24);
+        line-height: 1.333;
+        font-weight: 700;
+        color: var(--ons-color-ocean-blue);
+        margin-bottom: 0;
+
+        @include media-query('m') {
+            font-size: rem-sizing(26);
+            line-height: 1.384;
+        }
+    }
+
+    &__heading {
+        line-height: 1.375;
+        margin-bottom: rem-sizing(16);
+
+        @include media-query('m') {
+            line-height: 1.1667;
+        }
+    }
+
+    &__summary {
+        margin-bottom: rem-sizing(96);
+
+        @include media-query('m') {
+            margin-bottom: rem-sizing(64);
+        }
+    }
+}

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_document-list.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_document-list.scss
@@ -1,6 +1,19 @@
+@use 'config' as *;
+
 // overrides to ons list styles
 .ons-document-list {
     &__item-attribute {
         line-height: 1.714;
+    }
+
+    &__item-title,
+    .ons-document-list__item--featured &__item-title {
+        font-size: rem-sizing(20);
+        line-height: 1.4;
+
+        @include media-query('m') {
+            font-size: rem-sizing(22);
+            line-height: 1.455;
+        }
     }
 }

--- a/ons_alpha/static_src/sass/config.scss
+++ b/ons_alpha/static_src/sass/config.scss
@@ -1,3 +1,4 @@
 // Abstracts
 @forward 'config/functions';
 @forward 'config/mixins';
+@forward 'config/variables';

--- a/ons_alpha/static_src/sass/config/_variables.scss
+++ b/ons_alpha/static_src/sass/config/_variables.scss
@@ -8,3 +8,10 @@ $breakpoints: (
     'xl' '(min-width: 1300px)',
     '2xl' '(min-width: 1600px)'
 );
+
+// These colour variables are set in the figma file but not in the design-system
+
+$color--buff: #e8bb9b;
+$color--pale-grey: #efeff0;
+$color--pale-blue: #e7eff4;
+$color--grey-blue: #dee7ee;

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -13,6 +13,7 @@
 @use 'components/panel';
 @use 'components/rich-text';
 @use 'components/streamfield';
+@use 'components/topic-header';
 
 // ONS design system overrides
 @use 'components/design_system_overrides/breadcrumbs';


### PR DESCRIPTION
### What is the context of this PR?
- Layout for the topic page
- Styling for the topic page header area with the floaty circles
- Some adjustments to the bulletin page header to be in line with the topic page header
- Move custom colours to the variables scss partial
- Styling for the featured document block
- Tweaks to heading size document list block and featured document block
- Fix spacing after document list block and featured document block
- Fix arguments  from python for the featured document block after the design system updates - this was previously done for the document list block but was missed for this one - see https://github.com/ONSdigital/design-system/blob/d3c30b9400c9f0bdfca21f838d82b8890bd1ec05/migration_guides/70.x.x-to-72.0.0-migration-guide.md?plain=1#L919-L972

### How to review
- Edit a topic page to add content similar to that in the figma file
- Check everything looks ok at desktop and mobile

### Screenshots

<details>
<summary>Look in here</summary>

**Desktop**

![screencapture-localhost-8000-topic-section-topic-page-2024-10-17-10_45_55](https://github.com/user-attachments/assets/210d2126-740c-4d32-afba-6ea6d71e652f)

**Mobile**

![screencapture-localhost-8000-topic-section-topic-page-2024-10-17-10_46_16](https://github.com/user-attachments/assets/ede2080a-5c20-4d9c-9049-298bb1969eda)

</details>
