### PR TITLE
Bulletin page tweaks after feedback

### DIFF
--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -1,10 +1,10 @@
 <div class="ons-container headline-figures">
-    <h2 class="headline-figures__heading ons-u-fs-l">Headline figures</h2>
+    <h2 class="headline-figures__heading ons-u-fs-l">Headline facts and figures</h2>
     <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--24 headline-figures__grid">
         {% for figure in value %}
             <div class="ons-grid__col">
                 <div class="headline-figures__block">
-                    <h3 class="headline-figures__title ons-u-fs-l">{{ figure.title }}</h3>
+                    <h3 class="headline-figures__title">{{ figure.title }}</h3>
                     <p class="headline-figures__figure">{{ figure.figure }}</p>
 
                     {% if figure.supporting_text %}

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -15,6 +15,8 @@
                     <h1 class="ons-u-fs-3xl bulletin-header__heading">
                         {{ page.full_title }}
                     </h1>
+
+                    <p class="bulletin-header__summary">{{ page.summary }}</p>
                 </div>
                 <div class="ons-grid__col ons-col-2@m bulletin-header__kitemark">
                     {% if page.is_accredited %}
@@ -26,19 +28,15 @@
             </div>
         </div>
 
-        <div class="ons-container">
-            <p class="bulletin-header__summary">{{ page.summary }}</p>
-        </div>
-
         {% block release_meta %}
             <div class="ons-container">
                 <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
                     <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b">{{ _("Release date") }}:</span>
+                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Release date") }}:</span>
                         <span class="ons-u-nowrap">{{ page.release_date|date("j F Y") }}</span>
                     </div>
                     <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b">{{ _("Version") }}:</span>
+                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Version") }}:</span>
                         {% if latest_version_url %}
                             <span>{{ _("This has been superseded.") }} <a href="{{ latest_version_url }}">{{ _("View corrected version") }}</a></span>
                         {% else %}
@@ -46,19 +44,19 @@
                         {% endif %}
                     </div>
                     <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b">{{ _("Contact") }}:</span>
+                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Contact") }}:</span>
                         <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
                     </div>
                 </div>
                 <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
                     <div class="ons-grid__col ons-col-4@m">
                         {% if page.next_release_date %}
-                            <span class="ons-u-fs-r--b">{{ _("Next release") }}:</span>
+                            <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Next release") }}:</span>
                             <span class="ons-u-nowrap">{{ page.next_release_date|date("j F Y") }}</span>
                         {% endif %}
                     </div>
                     <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b">{{ _("Releases") }}:</span>
+                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Releases") }}:</span>
                         {% if page.is_latest %}
                             <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
                         {% else %}

--- a/ons_alpha/static_src/sass/components/_bulletin-header.scss
+++ b/ons_alpha/static_src/sass/components/_bulletin-header.scss
@@ -85,4 +85,8 @@
         row-gap: rem-sizing(8);
         margin-bottom: rem-sizing(8);
     }
+
+    &__releases-label {
+        margin-right: 16px;
+    }
 }

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -28,18 +28,22 @@
     }
 
     &__heading {
-        line-height: 1.333;
+        font-size: rem-sizing(26);
+        line-height: 1.385;
         margin-bottom: rem-sizing(16);
 
         @include media-query('m') {
-            line-height: 1.385;
+            font-size: rem-sizing(30);
+            line-height: 1.333;
         }
     }
 
     &__title {
+        font-size: rem-sizing(24);
         line-height: 1.333;
 
         @include media-query('m') {
+            font-size: rem-sizing(26);
             line-height: 1.385;
         }
     }
@@ -50,6 +54,10 @@
         font-weight: 700;
         line-height: 1.375;
         margin-bottom: 0;
+
+        @include media-query('s') {
+            margin-bottom: rem-sizing(8);
+        }
 
         @include media-query('m') {
             font-size: rem-sizing(36);

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_container.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_container.scss
@@ -3,6 +3,6 @@
 // overrides to ons container styles
 .ons-container {
     max-width: rem-sizing(
-        1060
+        1056
     ); // with 1rem padding either side, content is then 1024px wide to match the designs
 }


### PR DESCRIPTION
### What is the context of this PR?
- Makes a couple of layout tweaks to the bulletin page header - the summary now has the same maximum width as the page title, and there is some spacing between the labels and text in the 'releases' area
- Tweaks the font-sizes for the 'headline facts and figures' which were somehow wrong again
- Updates the hard-coded heading for 'headline facts and figures'

### How to review
Re-test a bulletin page

### Screenshots

<details>
<summary>in here</summary>

Headline facts and figures - ringed elements have changed font-size, extra space below the figure

![Screenshot 2024-10-18 at 11 57 11](https://github.com/user-attachments/assets/64fa01f1-d18c-459f-9ae7-3e34186b33fe)

Bulletin page header - line shows extra space, text in square has moved below the heading and inside a container with a max-width

![Screenshot 2024-10-18 at 11 57 03](https://github.com/user-attachments/assets/27d4b2f7-9aa3-432f-87fb-c1aae54e5ee7)

</details>