### PR TITLE
November prototype - landing page styling

### DIFF
--- a/ons_alpha/core/blocks/stream_blocks.py
+++ b/ons_alpha/core/blocks/stream_blocks.py
@@ -28,6 +28,9 @@ class SimpleStoryBlock(StreamBlock):
     document_list = DocumentListBlock()
     button_link = ButtonLinkBlock()
 
+    class Meta:
+        template = "templates/components/streamfield/stream_block.html"
+
 
 class CoreStoryBlock(StreamBlock):
     heading = HeadingBlock()

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -36,7 +36,11 @@
     }}
 {% endset %}
 
-{% set body_class = ["template-", page.get_verbose_name()| lower | replace(" ", "-")] | join %}
+{% if page %}
+    {% set body_class = ["template-", page.get_verbose_name()| lower | replace(" ", "-")] | join %}
+{% else %}
+    {% set body_class = '' %}
+{% endif %}
 
 {# navlinks are hard-code for the prototype #}
 {% set pageConfig = {

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -36,8 +36,11 @@
     }}
 {% endset %}
 
+{% set body_class = ["template-", page.get_verbose_name()| lower | replace(" ", "-")] | join %}
+
 {# navlinks are hard-code for the prototype #}
 {% set pageConfig = {
+    "bodyClasses": body_class,
     "header": {
         "title": page_title,
         "phase": {

--- a/ons_alpha/jinja2/templates/components/streamfield/button_link_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/button_link_block.html
@@ -1,7 +1,11 @@
 {% from "components/button/_macro.njk" import onsButton %}
+{# fmt:off #}
 {{
-onsButton({
-"text": text,
-"url": url,
-})
+    onsButton({
+        "text": text,
+        "url": url,
+        "iconType": "chevron",
+        "iconPosition": "after",
+    })
 }}
+{# fmt:on #}

--- a/ons_alpha/jinja2/templates/components/streamfield/stream_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/stream_block.html
@@ -1,8 +1,9 @@
 {% for content_block in value %}
     {% with block_id = content_block.id %}
         <div class="
-                    {% if content_block.block_type !='heading' %}streamfield{% endif %}
-                    {% if last_flush %}streamfield--last-flush{% endif %}
+                    {% if content_block.block_type !='heading' %}streamfield
+                        {% if last_flush %}streamfield--last-flush{% endif %}
+                    {% endif %}
                    ">
             {% include_block content_block %}
         </div>

--- a/ons_alpha/jinja2/templates/pages/information_page.html
+++ b/ons_alpha/jinja2/templates/pages/information_page.html
@@ -2,17 +2,30 @@
 {% from "components/related-content/_macro.njk" import onsRelatedContent %}
 
 {% block header_area %}
-    <div class="generic-header">
+    <div class="landing-header">
+        <div class="landing-header__circles" aria-hidden="true">
+            <div class="landing-header__circle-one"></div>
+            <div class="landing-header__circle-two"></div>
+            <div class="landing-header__circle-three"></div>
+            <div class="landing-header__circle-four"></div>
+            <div class="landing-header__circle-five"></div>
+            <div class="landing-header__circle-six"></div>
+            <div class="landing-header__circle-seven"></div>
+            <div class="landing-header__circle-eight"></div>
+            <div class="landing-header__circle-nine"></div>
+            <div class="landing-header__circle-ten"></div>
+            <div class="landing-header__circle-eleven"></div>
+        </div>
         <div class="ons-container">
             {% block breadcrumbs %}
                 {% include "templates/components/navigation/breadcrumbs.html" %}
             {% endblock %}
             <div class="ons-grid">
                 <div class="ons-grid__col ons-col-8@m ">
-                    <h1 class="ons-u-fs-3xl generic-header__heading">{{ page.h1 }}</h1>
-                    {% if page.summary %}
-                        <p class="generic-header__summary">{{ page.summary }}</p>
-                    {% endif %}
+                    <h1 class="ons-u-fs-3xl landing-header__heading">
+                        {{ page.h1 }}
+                    </h1>
+                    <p class="landing-header__summary">{{ page.summary }}</p>
                 </div>
             </div>
         </div>

--- a/ons_alpha/jinja2/templates/pages/information_page.html
+++ b/ons_alpha/jinja2/templates/pages/information_page.html
@@ -39,6 +39,8 @@
     <div class="ons-container">
         <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
             <div class="ons-grid__col ons-col-8@m">
+                {# Remove bottom margin from last streamfield block. last_flush is used in stream_block.html #}
+                {% set last_flush = True %}
                 {% include_block page.body %}
             </div>
         </div>

--- a/ons_alpha/static_src/sass/components/_landing-header.scss
+++ b/ons_alpha/static_src/sass/components/_landing-header.scss
@@ -1,0 +1,253 @@
+@use 'config' as *;
+
+.landing-header {
+    // this colour is in figma but not in the design system
+    background-color: $color--deep-grey-blue;
+    color: var(--ons-color-white);
+    position: relative;
+    padding-bottom: rem-sizing(96);
+    margin-bottom: rem-sizing(40);
+    overflow: hidden;
+
+    @include media-query('l') {
+        padding-bottom: rem-sizing(64);
+    }
+
+    &::before {
+        position: absolute;
+        inset: 0;
+        width: 150%;
+        height: 100%;
+        left: -40%;
+        border-radius: 0 0 50% 50%;
+        // this colour is in figma but not in the design system
+        background-color: $color--midnight-blue;
+        content: '';
+
+        @include media-query('l') {
+            border-radius: 0 0 300% 80%;
+            width: 100%;
+            left: 0;
+        }
+    }
+
+    // home page has no breadcrumbs
+    .template-home-page & {
+        padding-top: rem-sizing(64);
+    }
+
+    &__circle-one {
+        @include media-query('l') {
+            position: absolute;
+            width: 59px;
+            height: 59px;
+            background-color: var(--ons-color-spring-green);
+            border-radius: 50%;
+            top: -11px;
+            right: 289px;
+        }
+    }
+
+    &__circle-two {
+        @include media-query('l') {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 11px;
+            right: 193px;
+        }
+    }
+
+    &__circle-three {
+        @include media-query('l') {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 25px;
+            right: 112px;
+        }
+    }
+
+    &__circle-four {
+        @include media-query('l') {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 80px;
+            right: 208px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-ocean-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.4;
+            }
+        }
+    }
+
+    &__circle-five {
+        @include media-query('l') {
+            position: absolute;
+            width: 14px;
+            height: 14px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 187px;
+            right: 222px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-sky-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.7;
+            }
+        }
+    }
+
+    &__circle-six {
+        @include media-query('l') {
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            background-color: var(--ons-color-spring-green);
+            border-radius: 50%;
+            top: 188px;
+            right: 135px;
+        }
+    }
+
+    &__circle-seven {
+        @include media-query('l') {
+            position: absolute;
+            width: 60px;
+            height: 60px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            top: 188px;
+            right: 24px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-night-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.7;
+            }
+        }
+    }
+
+    &__circle-eight {
+        @include media-query('l') {
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            bottom: 27px;
+            right: 275px;
+        }
+    }
+
+    &__circle-nine {
+        @include media-query('l') {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: var(--ons-color-spring-green);
+            border-radius: 50%;
+            bottom: -4px;
+            right: 215px;
+        }
+    }
+
+    &__circle-ten {
+        @include media-query('l') {
+            position: absolute;
+            width: 15px;
+            height: 15px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            bottom: 20px;
+            right: 120px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-aqua-teal);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.4;
+            }
+        }
+    }
+
+    &__circle-eleven {
+        @include media-query('l') {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: var(--ons-color-white);
+            border-radius: 50%;
+            bottom: -10px;
+            right: 75px;
+
+            // use a before element over the white background
+            // to get the correct overlaid colour
+            &::before {
+                content: '';
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                background-color: var(--ons-color-sky-blue);
+                border-radius: 50%;
+                top: 0;
+                left: 0;
+                opacity: 0.7;
+            }
+        }
+    }
+
+    &__heading {
+        line-height: 1.375;
+        margin-bottom: rem-sizing(16);
+
+        @include media-query('m') {
+            line-height: 1.1667;
+        }
+    }
+
+    &__summary {
+        margin-bottom: 0;
+    }
+}

--- a/ons_alpha/static_src/sass/components/_rich-text.scss
+++ b/ons_alpha/static_src/sass/components/_rich-text.scss
@@ -12,4 +12,12 @@
             list-style-type: disc;
         }
     }
+
+    hr {
+        margin-bottom: rem-sizing(32);
+    }
+
+    p {
+        margin-bottom: rem-sizing(32);
+    }
 }

--- a/ons_alpha/static_src/sass/components/_topic-header.scss
+++ b/ons_alpha/static_src/sass/components/_topic-header.scss
@@ -4,7 +4,7 @@
     // this colour is in figma but not in the design system
     background-color: $color--grey-blue;
     position: relative;
-    padding-bottom: rem-sizing(64);
+    padding-bottom: rem-sizing(96);
     margin-bottom: rem-sizing(40);
     overflow: hidden;
 
@@ -24,6 +24,10 @@
             left: -25%;
             width: 130%;
         }
+    }
+
+    @include media-query('l') {
+        padding-bottom: rem-sizing(64);
     }
 
     &__circle-one {
@@ -47,7 +51,7 @@
         background-color: $color--buff;
         border-radius: 50%;
         // these are relative to the 'before' styled curve
-        bottom: 7%;
+        bottom: 4%;
         right: 15%;
 
         @include media-query('l') {
@@ -68,7 +72,7 @@
         height: 80px;
         background-color: var(--ons-color-ocean-blue);
         border-radius: 50%;
-        bottom: 10%;
+        bottom: 7%;
         right: -26px;
 
         @include media-query('l') {
@@ -105,10 +109,10 @@
     }
 
     &__summary {
-        margin-bottom: rem-sizing(96);
+        margin-bottom: rem-sizing(24);
 
         @include media-query('m') {
-            margin-bottom: rem-sizing(64);
+            margin-bottom: 0;
         }
     }
 }

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_breadcrumbs.scss
@@ -12,4 +12,12 @@
         padding-bottom: rem-sizing(8);
         line-height: 1.714;
     }
+
+    // breadcrumbs need to be white on the dark blue background
+    &__link {
+        .template-information-page & {
+            color: var(--ons-color-white);
+            text-decoration-color: var(--ons-color-white);
+        }
+    }
 }

--- a/ons_alpha/static_src/sass/config/_variables.scss
+++ b/ons_alpha/static_src/sass/config/_variables.scss
@@ -15,3 +15,5 @@ $color--buff: #e8bb9b;
 $color--pale-grey: #efeff0;
 $color--pale-blue: #e7eff4;
 $color--grey-blue: #dee7ee;
+$color--midnight-blue: #153b55;
+$color--deep-grey-blue: #194766;

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -9,6 +9,7 @@
 @use 'components/contact-details';
 @use 'components/footer';
 @use 'components/headline-figures';
+@use 'components/landing-header';
 @use 'components/navigation';
 @use 'components/panel';
 @use 'components/rich-text';


### PR DESCRIPTION
### What is the context of this PR?
- Adds the 'landing page' header area styling with lots of circles (used on home page and information page)
- Add the page type to the body class in order to add variations for home page and information page, depending on whether breadcrumbs are included
- Tweak padding on the topic page header area (I spotted it had too much)
- Styling for paragraph and hrs in rich text
- Use the stream block template to get the correct spacing between blocks on the home page and information page
- Update the icon used on the 'get started' button.

### How to review
Edit the home page on your local build to test the styles look like the figma file. Do the same with an information page.
