### PR TITLE
Chart block changes

### DIFF
--- a/ons_alpha/core/blocks/embeddable.py
+++ b/ons_alpha/core/blocks/embeddable.py
@@ -88,7 +88,10 @@ class ONSChartEmbedBlock(ONSEmbedBlock):
         help_text="Title for the embedded chart e.g. 'Online sales rose for most main sectors'",
     )
     chart_title = blocks.CharBlock(
-        help_text="Detailed chart title, e.g. 'Figure 3: Value sales, monthly percentage change, seasonally adjusted, Great Britain, July 2024'"
+        help_text="""
+            Detailed chart title, e.g.
+            'Figure 3: Value sales, monthly percentage change, seasonally adjusted, Great Britain, July 2024'
+            """
     )
     downloads_heading = blocks.CharBlock(default="Download Figure X data")
     downloads_content = blocks.RichTextBlock(features=settings.RICH_TEXT_BASIC)

--- a/ons_alpha/core/blocks/embeddable.py
+++ b/ons_alpha/core/blocks/embeddable.py
@@ -64,7 +64,7 @@ ONS_EMBED_PREFIX = "https://www.ons.gov.uk/"
 
 class ONSEmbedBlock(blocks.StructBlock):
     url = blocks.URLBlock(label="URL", help_text=f"Must start with <code>{ ONS_EMBED_PREFIX }</code> to your URL.")
-    title = blocks.CharBlock(default="Interactive chart")
+    title = blocks.CharBlock(default="Embedded content")
 
     def clean(self, value):
         errors = {}
@@ -83,6 +83,13 @@ class ONSEmbedBlock(blocks.StructBlock):
 
 
 class ONSChartEmbedBlock(ONSEmbedBlock):
+    title = blocks.CharBlock(
+        default="Interactive chart",
+        help_text="Title for the embedded chart e.g. 'Online sales rose for most main sectors'",
+    )
+    chart_title = blocks.CharBlock(
+        help_text="Detailed chart title, e.g. 'Figure 3: Value sales, monthly percentage change, seasonally adjusted, Great Britain, July 2024'"
+    )
     downloads_heading = blocks.CharBlock(default="Download Figure X data")
     downloads_content = blocks.RichTextBlock(features=settings.RICH_TEXT_BASIC)
     footnotes = blocks.RichTextBlock(features=settings.RICH_TEXT_BASIC, required=False)

--- a/ons_alpha/jinja2/templates/components/streamfield/ons_chart_embed_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/ons_chart_embed_block.html
@@ -17,6 +17,7 @@
     <h4 class="heading-4">{{ value.downloads_heading }}</h4>
     {{ value.downloads_content }}
     {% if value.footnotes %}
+        {% set unique_id = ["footnotes-", block_id] | join %}
         {# fmt:off #}
         {{
             onsDetails({

--- a/ons_alpha/jinja2/templates/components/streamfield/ons_chart_embed_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/ons_chart_embed_block.html
@@ -1,9 +1,11 @@
-{# This is used to embed charts. If we want to use it for other embeds like video
-    in the future we might need a separate block for those.
+{# This is used to embed charts.
     pym.js handles the responsive aspect ratio for the iframe. #}
+
+{% from "components/details/_macro.njk" import onsDetails %}
 
 <h3 class="heading-3 chart-embed__heading">{{ value.title }}</h3>
 <div class="chart-embed">
+    <h4 class="heading-4">{{ value.chart_title }}</h4>
     <div class="pym-interactive"
          id="{{ block_id }}"
          data-url="{{ value.url }}"
@@ -12,10 +14,17 @@
                 title="{{ value.title }}">
         </iframe>
     </div>
-    <h4 class="heading-4 chart-embed__downloads-heading">{{ value.downloads_heading }}</h4>
+    <h4 class="heading-4">{{ value.downloads_heading }}</h4>
     {{ value.downloads_content }}
     {% if value.footnotes %}
-        <h4 class="heading-4 chart-embed__footnotes-heading">Footnotes</h4>
-        {{ value.footnotes }}
+        {# fmt:off #}
+        {{
+            onsDetails({
+                "id": unique_id,
+                "title": "Footnotes",
+                "content": value.footnotes
+            })
+        }}
+        {# fmt:on #}
     {% endif %}
 </div>


### PR DESCRIPTION
### What is the context of this PR?
- Footnotes styling
- Tweaks to embed templates
- Add an extra field for the 'chart title' as these are not included in the charts from data vis

### How to review
- Try adding a chart block with one of the charts provided by the data vis team on slack
- Check all the styling looks correct
- Note that the charts do not consistently get resized correctly with the third party js - this is a known issue which will be tackled in a separate pr.

### Screenshots
<details>
<summary>
Look in here
</summary>

![Screenshot 2024-10-21 at 12 36 58](https://github.com/user-attachments/assets/e9e0616f-4152-4485-bfde-9a46d835ca38)
![Screenshot 2024-10-21 at 12 36 51](https://github.com/user-attachments/assets/6c3fbef9-185d-4d93-a301-80ee05ff0512)

</details>



