### PR TITLE
Fix-  iframe resize issue

### DIFF
--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -151,6 +151,4 @@
     <script async src="{{ static('js/third-party/pym.min.js') }}"></script>
     <script async src="{{ static('js/blocks/embeddable.js') }}"></script>
 
-    {# HACK: We can't use the built-in inclusion tag, so import the template _directly_. #}
-    {{ include_django("wagtailcharts/tags/render_charts.html") }}
 {% endblock %}


### PR DESCRIPTION
### What is the context of this PR?
There was a intermittent bug with the embedded chart iframes not resizing, which was down to interference from the wagtail chart js.

Note that this is a quick fix - we may want to remove wagtail charts more fully from the november prototype branch.

### How to review
Create a bulletin page with a few charts, and load it several times. Make sure the charts always load at 100% width of the parent.
