### PR TITLE
Add link option, and update styling for headline facts and figures block

### DIFF
--- a/ons_alpha/core/blocks/headline_figures.py
+++ b/ons_alpha/core/blocks/headline_figures.py
@@ -1,13 +1,10 @@
 from django.utils.translation import gettext as _
-from wagtail.blocks import (
-    CharBlock,
-    ListBlock,
-    StructBlock,
-)
+from wagtail.blocks import CharBlock, ListBlock, PageChooserBlock, StructBlock
 
 
 class HeadlineFiguresItemBlock(StructBlock):
     title = CharBlock(label=_("Title"), max_length=60, required=True)
+    title_link = PageChooserBlock(required=False)
     figure = CharBlock(label=_("Figure"), max_length=10, required=True)
     supporting_text = CharBlock(label=_("Supporting text"), max_length=100, required=False)
 

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -4,7 +4,15 @@
         {% for figure in value %}
             <div class="ons-grid__col">
                 <div class="headline-figures__block">
-                    <h3 class="headline-figures__title">{{ figure.title }}</h3>
+                    <h3 class="headline-figures__title">
+                        {% if figure.title_link %}
+                            <a href="{{ pageurl(figure.title_link) }}">
+                        {% endif %}
+                        {{ figure.title }}
+                        {% if figure.title_link %}
+                            </a>
+                        {% endif %}
+                    </h3>
                     <p class="headline-figures__figure">{{ figure.figure }}</p>
 
                     {% if figure.supporting_text %}

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -13,8 +13,7 @@
         grid-template-columns: 1fr 1fr;
         height: 100%;
         column-gap: rem-sizing(40);
-        background-color: var(--ons-color-ocean-blue);
-        color: var(--ons-color-white);
+        background-color: var(--ons-color-grey-5);
         padding: rem-sizing(24);
 
         @include media-query('s') {
@@ -23,7 +22,7 @@
         }
 
         @media (forced-colors: active) {
-            border: 1px solid var(--ons-color-ocean-blue);
+            border: 1px solid var(--ons-color-grey-5);
         }
     }
 
@@ -39,12 +38,12 @@
     }
 
     &__title {
-        font-size: rem-sizing(24);
-        line-height: 1.333;
+        font-size: rem-sizing(20);
+        line-height: 1.4;
 
         @include media-query('m') {
-            font-size: rem-sizing(26);
-            line-height: 1.385;
+            font-size: rem-sizing(22);
+            line-height: 1.454;
         }
     }
 


### PR DESCRIPTION
### What is the context of this PR?
See https://jira.ons.gov.uk/browse/NWP-526
- Changes background colour and text colour for headline facts and figures block
- Adds the option for a page link on the title
- Amend font-sizes (again...)

### How to review
Edit a bulletin page or a topic page and add some headline facts and figures, including some with a link and some without.
Ensure the link functions and that the styling matches the updated figma design

### Screenshots
<details>
<summary>
In here
</summary>

![Screenshot 2024-10-21 at 15 34 30](https://github.com/user-attachments/assets/4b627adf-e4ed-4008-b6b9-972081c7f851)

</details>