### PR TITLE
Continue to work on iframe resize issue

### DIFF
--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -149,6 +149,7 @@
     {{ super() }}
     <script async src="{{ mathjax() }}"></script>
     <script async src="{{ static('js/third-party/pym.min.js') }}"></script>
-    <script async src="{{ static('js/blocks/embeddable.js') }}"></script>
+    <script src="{{ static('js/blocks/embeddable.js') }}"></script>
+
 
 {% endblock %}


### PR DESCRIPTION


### What is the context of this PR?
- We are continuing to see issues with iframes not being resized
- This is another change in addition to the removal of the wagtail charts js (that change is still needed)
- Don't load the script that actually runs the resize asynchronously

### How to review
- Test a bulletin page with charts and see if the iframes resize consistently. Note that after a while you get temporarily blocked from loading the data vis charts.
- This change seems to help but I'm not 100% certain that it will resolve the issue completely yet.
