### PR TITLE
Add cookie banner to November prototype

### DIFF
--- a/ons_alpha/core/context_processors.py
+++ b/ons_alpha/core/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import reverse
 
 from ons_alpha.core.models import Tracking
 
@@ -11,4 +12,7 @@ def global_vars(request):
         "LANGUAGE_CODE": settings.LANGUAGE_CODE,
         "IS_EXTERNAL_ENV": settings.IS_EXTERNAL_ENV,
         "TOPIC_PAGE_URL": settings.ONS_TOPIC_PAGE_URL,
+        "COOKIE_BANNER_ENABLED": settings.ONS_COOKIE_BANNER_ENABLED,
+        "COOKIE_BANNER_SERVICE_NAME": settings.ONS_COOKIE_BANNER_SERVICE_NAME or request.get_host(),
+        "MANAGE_COOKIE_SETTINGS_URL": reverse("manage-cookie-settings"),
     }

--- a/ons_alpha/core/tests/test_context_processors.py
+++ b/ons_alpha/core/tests/test_context_processors.py
@@ -8,16 +8,8 @@ from ons_alpha.core.models import Tracking
 class GlobalVarsContextProcessorTest(TestCase):
     def test_when_no_tracking_settings_defined(self):
         request = RequestFactory().get("/")
-        self.assertEqual(
-            global_vars(request),
-            {
-                "GOOGLE_TAG_MANAGER_ID": "",
-                "SEO_NOINDEX": True,
-                "LANGUAGE_CODE": "en-gb",
-                "IS_EXTERNAL_ENV": False,
-                "TOPIC_PAGE_URL": "/business-industry-trade/retail-industry/",
-            },
-        )
+        result = global_vars(request)
+        self.assertEqual(result["GOOGLE_TAG_MANAGER_ID"], "")
 
     def test_when_tracking_settings_defined(self):
         Tracking.objects.create(
@@ -25,13 +17,5 @@ class GlobalVarsContextProcessorTest(TestCase):
             google_tag_manager_id="GTM-123456",
         )
         request = RequestFactory().get("/")
-        self.assertEqual(
-            global_vars(request),
-            {
-                "GOOGLE_TAG_MANAGER_ID": "GTM-123456",
-                "SEO_NOINDEX": True,
-                "LANGUAGE_CODE": "en-gb",
-                "IS_EXTERNAL_ENV": False,
-                "TOPIC_PAGE_URL": "/business-industry-trade/retail-industry/",
-            },
-        )
+        result = global_vars(request)
+        self.assertEqual(result["GOOGLE_TAG_MANAGER_ID"], "GTM-123456")

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -339,100 +339,100 @@
 
 {# Note that the footer links are hard-coded for the November prototype and do not link anywhere #}
 {% block footer %}
+    {# fmt:off #}
     {{
-    onsFooterNew({
-    "cols": [
-    {
-    "title": 'Help',
-    "itemsList": [
-    {
-    "text": 'Accessibility',
-    "url": False
-    },
-    {
-    "text": 'Cookies',
-    "url": False
-    },
-    {
-    "text": 'Privacy',
-    "url": False
-    },
-    {
-    "text": 'Terms and conditions',
-    "url": False
-    }
-    ]
-    },
-    {
-    "title": 'About ONS',
-    "itemsList": [
-    {
-    "text": 'What we do',
-    "url": False
-    },
-    {
-    "text": 'Careers',
-    "url": False
-    },
-    {
-    "text": 'Contact us',
-    "url": False
-    },
-    {
-    "text": 'News',
-    "url": False
-    },
-    {
-    "text": 'Freedom of information',
-    "url": False
-    }
-    ]
-    },
-    {
-    "title": 'Connect with us',
-    "itemsList": [
-    {
-    "text": 'Twitter',
-    "external": true,
-    "url": False
-    },
-    {
-    "text": 'Instagram',
-    "external": true,
-    "url": False
-    },
-    {
-    "text": 'Facebook',
-    "external": true,
-    "url": False
-    },
-    {
-    "text": 'Linkedin',
-    "external": true,
-    "url": False
-    },
-    {
-    "text": 'Consultations',
-    "url": False
-    },
-    {
-    "text": 'Discussion forums',
-    "url": False
-    },
-    {
-    "text": 'Email alerts',
-    "url": False
-    }
-    ]
-    }
-    ],
-    "legal": [
-    ],
-    "oglLink": True,
-    "footerLogo": {
-    },
-    })
+        onsFooterNew({
+            "cols": [
+                {
+                    "title": 'Help',
+                    "itemsList": [
+                        {
+                            "text": 'Accessibility',
+                            "url": 'https://www.ons.gov.uk/help/accessibility'
+                        },
+                        {
+                            "text": 'Cookies',
+                            "url": url('manage-cookie-settings')
+                        },
+                        {
+                            "text": 'Privacy',
+                            "url": 'https://www.ons.gov.uk/help/privacynotice'
+                        },
+                        {
+                            "text": 'Terms and conditions',
+                            "url": 'https://www.ons.gov.uk/help/termsandconditions'
+                        }
+                    ]
+                },
+                {
+                    "title": 'About ONS',
+                    "itemsList": [
+                        {
+                            "text": 'What we do',
+                            "url": False
+                        },
+                        {
+                            "text": 'Careers',
+                            "url": False
+                        },
+                        {
+                            "text": 'Contact us',
+                            "url": False
+                        },
+                        {
+                            "text": 'News',
+                            "url": False
+                        },
+                        {
+                            "text": 'Freedom of information',
+                            "url": False
+                        }
+                    ]
+                },
+                {
+                    "title": 'Connect with us',
+                    "itemsList": [
+                        {
+                            "text": 'Twitter',
+                            "external": true,
+                            "url": False
+                        },
+                        {
+                            "text": 'Instagram',
+                            "external": true,
+                            "url": False
+                        },
+                        {
+                            "text": 'Facebook',
+                            "external": true,
+                            "url": False
+                        },
+                        {
+                            "text": 'Linkedin',
+                            "external": true,
+                            "url": False
+                        },
+                        {
+                            "text": 'Consultations',
+                            "url": False
+                        },
+                        {
+                            "text": 'Discussion forums',
+                            "url": False
+                        },
+                        {
+                            "text": 'Email alerts',
+                            "url": False
+                        }
+                    ]
+                }
+            ],
+            "legal": [],
+            "oglLink": True,
+            "footerLogo": {},
+        })
     }}
+    {# fmt:on #}
 {% endblock %}
 
 {% block scripts %}

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -1,4 +1,5 @@
 {% extends "layout/_template.njk" %}
+{% from "components/cookies-banner/_macro.njk" import onsCookiesBanner %}
 {% from "component_overrides/header/_macro.njk" import onsHeaderNew %}
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 {% from "component_overrides/footer/_macro.njk" import onsFooterNew %}
@@ -281,6 +282,22 @@
 {% set page_title %}
     {% if current_site and page.pk == current_site.root_page.pk and current_site.site_name %}{{ current_site.site_name }} | {% endif %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title}}{% endif %}{% endblock %}{% block title_suffix %}{% if current_site and page.pk != current_site.root_page.pk and current_site.site_name %} | {{ current_site.site_name }}{% endif %}{% endblock %}
 {% endset %}
+
+{% block preHeader %}
+    {# Use same logic as the header to determine the correct language #}
+    {% set currentLanguage = pageConfig.header.language.languages | selectattr("current") | first %}
+    {% set currentLanguageIsoCode = currentLanguage.isoCode %}
+
+    {% if currentLanguageIsoCode == 'cy' %}
+        {{
+        onsCookiesBanner({
+        'lang': 'cy'
+        })
+        }}
+    {% else %}
+        {{ onsCookiesBanner() }}
+    {% endif %}
+{% endblock %}
 
 
 {% block head %}

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -288,15 +288,16 @@
     {% set currentLanguage = pageConfig.header.language.languages | selectattr("current") | first %}
     {% set currentLanguageIsoCode = currentLanguage.isoCode %}
 
-    {% if currentLanguageIsoCode == 'cy' %}
-        {{
+    {# fmt:off #}
+    {{
         onsCookiesBanner({
-        'lang': 'cy'
+            'lang': currentLanguageIsoCode,
+            'serviceName': request.get_host(),
+            'settingsLinkText': 'Manage cookie settings',
+            'settingsLinkUrl': url('manage-cookie-settings'),
         })
-        }}
-    {% else %}
-        {{ onsCookiesBanner() }}
-    {% endif %}
+    }}
+    {# fmt:on #}
 {% endblock %}
 
 

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -11,6 +11,53 @@
     {% endif %}
 {% endblock meta %}
 
+
+{% block head %}
+    <link rel="stylesheet" href="{{ static('css/main.css') }}">
+    {% if GOOGLE_TAG_MANAGER_ID and not request.is_preview %}
+        <!-- Google Tag Manager -->
+        <script>
+            function loadGTM() {
+                (function (w, d, s, l, i) {
+                    w[l] = w[l] || [];
+                    w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+                    var f = d.getElementsByTagName(s)[0],
+                        j = d.createElement(s),
+                        dl = l != 'dataLayer' ? '&l=' + l : '';
+                    j.async = true;
+                    j.src =
+                        'https://www.googletagmanager.com/gtm.js?id=' +
+                    i +
+                    dl +
+                    '&gtm_preview=env-12&gtm_cookies_win=x';
+                    f.parentNode.insertBefore(j, f);
+                })(window, document, 'script', 'dataLayer', '{{ GOOGLE_TAG_MANAGER_ID|escapejs }}');
+            }
+
+            var a = /^(.*)?\s*'usage':true\s*[^;]+(.*)?$/;
+            if (document.cookie.match(a)) {
+                loadGTM();
+            }
+        </script>
+        <!-- End Google Tag Manager -->
+    {% endif %}
+{% endblock %}
+
+{% block bodyStart %}
+    {% if GOOGLE_TAG_MANAGER_ID and not request.is_preview %}
+        <!-- Google Tag Manager (noscript) -->
+        <noscript
+        ><iframe
+            src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER_ID }}&amp;gtm_preview=env-12&amp;gtm_cookies_win=x"
+            height="0"
+            width="0"
+            style="display:none;visibility:hidden"
+        ></iframe
+            ></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+    {% endif %}
+{% endblock %}
+
 {# fmt:off #}
 {% set languages = languages | default([
     {
@@ -298,11 +345,6 @@
         })
     }}
     {# fmt:on #}
-{% endblock %}
-
-
-{% block head %}
-    <link rel="stylesheet" href="{{ static('css/main.css') }}">
 {% endblock %}
 
 {% block preMain %}

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -336,14 +336,16 @@
     {% set currentLanguageIsoCode = currentLanguage.isoCode %}
 
     {# fmt:off #}
-    {{
-        onsCookiesBanner({
-            'lang': currentLanguageIsoCode,
-            'serviceName': request.get_host(),
-            'settingsLinkText': 'Manage cookie settings',
-            'settingsLinkUrl': url('manage-cookie-settings'),
-        })
-    }}
+    {% if COOKIE_BANNER_ENABLED %}
+        {{
+            onsCookiesBanner({
+                'lang': currentLanguageIsoCode,
+                'serviceName': COOKIE_BANNER_SERVICE_NAME,
+                'settingsLinkText': 'Manage settings',
+                'settingsLinkUrl': MANAGE_COOKIE_SETTINGS_URL,
+            })
+        }}
+    {% endif %}
     {# fmt:on #}
 {% endblock %}
 
@@ -394,7 +396,7 @@
                         },
                         {
                             "text": 'Cookies',
-                            "url": url('manage-cookie-settings')
+                            "url": MANAGE_COOKIE_SETTINGS_URL
                         },
                         {
                             "text": 'Privacy',

--- a/ons_alpha/jinja2/templates/pages/manage_cookie_settings.html
+++ b/ons_alpha/jinja2/templates/pages/manage_cookie_settings.html
@@ -1,0 +1,388 @@
+{% extends "templates/base.html" %}
+{% from "components/radios/_macro.njk" import onsRadios %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/details/_macro.njk" import onsDetails %}
+{% from "components/table/_macro.njk" import onsTable %}
+
+{% block main %}
+    <div class="ons-page__body">
+        <h1 class="ons-u-fs-2xl">{{ page.title }}</h1>
+        {# fmt:off #}
+        {%
+            call onsPanel({
+                "classes": "ons-u-mb-l ons-u-d-no ons-cookies-confirmation-message",
+                "variant": "success",
+                "iconType": "check",
+                "iconSize": "xl"
+            })
+        %}
+        {# fmt:on #}
+        <h2>Your cookie settings have been saved</h2>
+        <p class="ons-u-mb-no">Some parts of this website may use additional cookies and will have their own cookie policy and banner.</p>
+        <a class="ons-u-mt-s ons-u-dib{{ ' ons-js-return-link' if not isDesignSystemExample }}" href="#0">Return to previous page</a>
+{% endcall %}
+
+<p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+<p>We use cookies to store information about how you use the ONS website, such as the pages you visit.</p>
+<h2>Cookie settings</h2>
+<div class="ons-u-db-no-js_enabled">
+    <p>We use JavaScript to set our cookies. Javascript is not running on your browser so you cannot change your settings.</p>
+    <p>You can try:</p>
+    <ul>
+        <li>turning on JavaScript in your browser</li>
+        <li>reloading the page in case there was a temporary fault with JavaScript</li>
+    </ul>
+</div>
+<div class="ons-u-db-no-js_disabled">
+    <p>We use three types of cookie. You can choose which cookies you're happy for us to use.</p>
+
+    <form data-module="cookie-settings">
+        <h3>Cookies that measure website use</h3>
+        <p>
+            We use Google Analytics to measure how you use the website so we can improve it based on user needs. Google Analytics
+            sets cookies that store anonymised information about:
+        </p>
+        <ul>
+            <li>how you got to the site</li>
+            <li>the pages you visit on ons.gov.uk and how long you spend on each page</li>
+            <li>what you click on while you're visiting the site</li>
+        </ul>
+        {# fmt:off #}
+        {%
+            call onsDetails({
+                "id": "cookies-measure-website-use-details",
+                "classes": "ons-u-mb-s",
+                "title": "Learn more about these Google Analytics cookies",
+                "headingLevel": 4,
+                "button": {
+                    "close": "Hide this"
+                }
+            })
+        %}
+            {{
+                onsTable({
+                    "ths": [
+                        {
+                            "value": "Name"
+                        },
+                        {
+                            "value": "Purpose"
+                        },
+                        {
+                            "value": "Expires"
+                        }
+                    ],
+                    "trs": [
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>_ga</code>"
+                                },
+                                {
+                                    "value": 'This helps us count how many people visit ons.gov.uk by tracking if you’ve visited before'
+                                },
+                                {
+                                    "value": "2 years"
+                                }
+                            ]
+                        },
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>_gid</code>"
+                                },
+                                {
+                                    "value": 'This helps us count how many people visit ons.gov.uk by tracking if you’ve visited before'
+                                },
+                                {
+                                    "value": "24 hours"
+                                }
+                            ]
+                        },
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>_gat</code>"
+                                },
+                                {
+                                    "value": 'Used to manage the rate at which page view requests are made'
+                                },
+                                {
+                                    "value": "10 minutes"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            }}
+        {% endcall %}
+        {# fmt:on #}
+        <p>We do not allow Google to use or share the data about how you use this site.</p>
+        <div class="ons-u-mb-s">
+            {# fmt:off #}
+            {{
+                onsRadios({
+                    "id": "cookies-measure-website-use",
+                    "name": "cookies-usage",
+                    "legend": "Do you want to allow usage tracking?",
+                    "legendClasses": "ons-u-vh",
+                    "radios": [
+                        {
+                            "id": "on-1",
+                            "label": {
+                                "text": "On"
+                            },
+                            "value": "on"
+                        },
+                        {
+                            "id": "off-1",
+                            "label": {
+                                "text": "Off"
+                            },
+                            "value": "off"
+                        }
+                    ]
+                })
+            }}
+            {# fmt:on #}
+        </div>
+        <p>This selection will expire after two years.</p>
+
+        <h3>Cookies that help with our communications</h3>
+        <p>
+            Some of our pages may contain content from other sites, like YouTube, which may set their own cookies. These sites are
+            sometimes called “third party” services. This tells us how many people are seeing the content and whether it’s useful.
+        </p>
+        <p>
+            In addition, if you share a link to a ons.gov.uk page, the service you share it on may set a cookie. We have no control
+            over cookies set on other websites – you can turn them off, but not through us.
+        </p>
+        <h4>YouTube videos</h4>
+        <p>We use YouTube to show videos on some ons.gov.uk pages. YouTube sets cookies when you visit one of these pages.</p>
+        {# fmt:off #}
+        {%
+            call onsDetails({
+                "id": "cookies-measure-website-comms-details",
+                "classes": "ons-u-mb-s",
+                "title": "Learn more about these YouTube cookies",
+                "headingLevel": 5,
+                "button": {
+                    "close": "Hide this"
+                }
+            })
+        %}
+            {{
+                onsTable({
+                    "ths": [
+                        {
+                            "value": "Name"
+                        },
+                        {
+                            "value": "Purpose"
+                        },
+                        {
+                            "value": "Expires"
+                        }
+                    ],
+                    "trs": [
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>_use_hitbox</code>"
+                                },
+                                {
+                                    "value": 'This is a randomly generated number that identifies your browser'
+                                },
+                                {
+                                    "value": "When you close your browser"
+                                }
+                            ]
+                        },
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>VISITOR_INFO1_LIVE</code>"
+                                },
+                                {
+                                    "value": 'Lets Youtube count the views of embedded Youtube videos'
+                                },
+                                {
+                                    "value": "9 months"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            }}
+        {% endcall %}
+        {{
+            onsRadios({
+                "id": "cookies-measure-website-comms",
+                "name": "cookies-campaigns",
+                "legend": "Do you want to allow communications tracking?",
+                "legendClasses": "ons-u-vh",
+                "radios": [
+                    {
+                        "id": "on-2",
+                        "label": {
+                            "text": "On"
+                        },
+                        "value": "on"
+                    },
+                    {
+                        "id": "off-2",
+                        "label": {
+                            "text": "Off"
+                        },
+                        "value": "off"
+                    }
+                ]
+            })
+        }}
+        {# fmt:on #}
+        <h3>Cookies that remember your settings</h3>
+        <p>
+            These cookies do things like remember your preferences and the choices you make, to personalise your experience of using
+            the site.
+        </p>
+        {# fmt:off #}
+        {{
+            onsRadios({
+                "id": "cookies-measure-website-settings",
+                "name": "cookies-settings",
+                "legend": "Do you want to allow settings?",
+                "legendClasses": "ons-u-vh",
+                "radios": [
+                    {
+                        "id": "on-3",
+                        "label": {
+                            "text": "On"
+                        },
+                        "value": "on"
+                    },
+                    {
+                        "id": "off-3",
+                        "label": {
+                            "text": "Off"
+                        },
+                        "value": "off"
+                    }
+                ]
+            })
+        }}
+        {# fmt:on #}
+        <h3>Strictly necessary cookies</h3>
+        <p>These essential cookies do things like:</p>
+        <ul>
+            <li>remember the notifications you've seen so we do not show them to you again</li>
+            <li>remember your progress through a form (for example, an ons study)</li>
+        </ul>
+        <p>They always need to be on.</p>
+        {# fmt:off #}
+        {%
+            call onsDetails({
+                "id": "cookies-essential-details",
+                "classes": "ons-u-mb-xl",
+                "title": "Learn more about these essential cookies",
+                "headingLevel": 4,
+                "button": {
+                    "close": "Hide this"
+                }
+            })
+        %}
+            <h5 class="ons-u-fs-r--b">Your progress when filling in a survey or questionnaire</h5>
+            <p>
+                We’ll set a cookie to remember your progress through a survey or questionnaire. These cookies do not store your
+                personal data and are deleted once you’ve completed the survey or questionnaire.
+            </p>
+            {{
+                onsTable({
+                    "ths": [
+                        {
+                            "value": "Name"
+                        },
+                        {
+                            "value": "Purpose"
+                        },
+                        {
+                            "value": "Expires"
+                        }
+                    ],
+                    "trs": [
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>licensing_session</code>"
+                                },
+                                {
+                                    "value": 'Set to remember information you’ve entered into a form'
+                                },
+                                {
+                                    "value": "When you close your browser"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            }}
+            <h5 class="ons-u-fs-r--b">Cookie message</h5>
+            <p>
+                You may see a banner when you visit ons.gov.uk inviting you to accept cookies or review your settings. We’ll set
+                cookies so that your computer knows you’ve seen it and not to show it again, and also to store your settings.
+            </p>
+            {{
+                onsTable({
+                    "ths": [
+                        {
+                            "value": "Name"
+                        },
+                        {
+                            "value": "Purpose"
+                        },
+                        {
+                            "value": "Expires"
+                        }
+                    ],
+                    "trs": [
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>ons_cookie_message_displayed</code>"
+                                },
+                                {
+                                    "value": 'Lets us know that you’ve seen our cookie message'
+                                },
+                                {
+                                    "value": "1 year"
+                                }
+                            ]
+                        },
+                        {
+                            "tds": [
+                                {
+                                    "value": "<code>ons_cookie_policy</code>"
+                                },
+                                {
+                                    "value": 'Saves your cookie consent settings'
+                                },
+                                {
+                                    "value": "1 year"
+                                }
+                            ]
+                        }
+                    ]
+                })
+            }}
+        {% endcall %}
+        {{
+            onsButton({
+                "type": 'submit',
+                "text": 'Save changes'
+            })
+        }}
+        {# fmt:on #}
+    </form>
+</div>
+</div>
+{% endblock %}

--- a/ons_alpha/settings/base.py
+++ b/ons_alpha/settings/base.py
@@ -829,6 +829,8 @@ SHORT_DATETIME_FORMAT = "d/m/Y P"
 ONS_TOPIC_PAGE_URL = env.get("ONS_TOPIC_PAGE_URL", "/business-industry-trade/retail-industry/")
 ONS_API_DATASET_BASE_URL = env.get("ONS_API_DATASET_BASE_URL", "https://api.beta.ons.gov.uk/v1/datasets")
 ONS_WEBSITE_DATASET_BASE_URL = env.get("ONS_WEBSITE_DATASET_BASE_URL", "https://www.ons.gov.uk/datasets")
+ONS_COOKIE_BANNER_ENABLED = env.get("ONS_COOKIE_BANNER_ENABLED", "false").lower() == "true"
+ONS_COOKIE_BANNER_SERVICE_NAME = env.get("ONS_COOKIE_BANNER_SERVICE_NAME")
 
 # Disable new version check and "what's new" banner
 WAGTAIL_ENABLE_UPDATE_CHECK = False

--- a/ons_alpha/urls.py
+++ b/ons_alpha/urls.py
@@ -13,6 +13,7 @@ from wagtail.utils.urlpatterns import decorate_urlpatterns
 from ons_alpha.images.views import ImageServeView
 from ons_alpha.search import views as search_views
 from ons_alpha.utils.cache import get_default_cache_control_decorator
+from ons_alpha.utils.views import ManageCookieSettingsView
 
 
 # Private URLs are not meant to be cached.
@@ -99,6 +100,11 @@ urlpatterns = (
         # Add Wagtail URLs at the end.
         # Wagtail cache-control is set on the page models' serve methods
         # and is handled conditionally on the search view
+        path(
+            "manage-cookie-settings/",
+            ManageCookieSettingsView.as_view(),
+            name="manage-cookie-settings",
+        ),
         path("search/", search_views.search, name="search"),
         path("", include(wagtail_urls)),
         prefix_default_language=False,

--- a/ons_alpha/utils/views.py
+++ b/ons_alpha/utils/views.py
@@ -35,5 +35,8 @@ class ManageCookieSettingsView(TemplateView):
 
         context = super().get_context_data(**kwargs)
         title = "Cookies on " + (settings.ONS_COOKIE_BANNER_SERVICE_NAME or self.request.get_host())
+        # NOTE: Templates wrongly assume that everything being rendered is
+        # a Wagtail page, hence the need to add a fake page object to the context
+        # This should be addressed properly in BETA!
         context["page"] = InformationPage(id=0, title=title)
         return context

--- a/ons_alpha/utils/views.py
+++ b/ons_alpha/utils/views.py
@@ -34,5 +34,6 @@ class ManageCookieSettingsView(TemplateView):
         from ons_alpha.standardpages.models import InformationPage
 
         context = super().get_context_data(**kwargs)
-        context["page"] = InformationPage(id=0, title=f"Cookies on {self.request.get_host()}")
+        title = "Cookies on " + (settings.ONS_COOKIE_BANNER_SERVICE_NAME or self.request.get_host())
+        context["page"] = InformationPage(id=0, title=title)
         return context

--- a/ons_alpha/utils/views.py
+++ b/ons_alpha/utils/views.py
@@ -2,8 +2,10 @@ import logging
 
 from http import HTTPStatus
 
+from django.conf import settings
 from django.shortcuts import render
 from django.views import defaults
+from django.views.generic import TemplateView
 
 
 def page_not_found(request, exception, template_name="templates/pages/errors/404.html"):
@@ -23,3 +25,14 @@ def csrf_failure(
     csrf_logger.exception("CSRF Failure: %s", reason)
 
     return render(request, template_name, status=HTTPStatus.FORBIDDEN)
+
+
+class ManageCookieSettingsView(TemplateView):
+    template_name = "templates/pages/manage_cookie_settings.html"
+
+    def get_context_data(self, **kwargs):
+        from ons_alpha.standardpages.models import InformationPage
+
+        context = super().get_context_data(**kwargs)
+        context["page"] = InformationPage(id=0, title=f"Cookies on {self.request.get_host()}")
+        return context

--- a/ons_alpha/utils/views.py
+++ b/ons_alpha/utils/views.py
@@ -7,6 +7,8 @@ from django.shortcuts import render
 from django.views import defaults
 from django.views.generic import TemplateView
 
+from ons_alpha.standardpages.models import InformationPage
+
 
 def page_not_found(request, exception, template_name="templates/pages/errors/404.html"):
     return defaults.page_not_found(request, exception, template_name)
@@ -31,8 +33,6 @@ class ManageCookieSettingsView(TemplateView):
     template_name = "templates/pages/manage_cookie_settings.html"
 
     def get_context_data(self, **kwargs):
-        from ons_alpha.standardpages.models import InformationPage
-
         context = super().get_context_data(**kwargs)
         title = "Cookies on " + (settings.ONS_COOKIE_BANNER_SERVICE_NAME or self.request.get_host())
         # NOTE: Templates wrongly assume that everything being rendered is


### PR DESCRIPTION
### What is the context of this PR?
Adds the cookie banner from the design system in English or Welsh
We don't have any design for the cookie banner in figma so this is using the default styling.

Additional work needed: create a page at /cookies to allow the user to set their preferences - see https://service-manual.ons.gov.uk/design-system/patterns/cookies-settings#cookie-preferences-page

### How to review
Describe the steps required to test the changes (include screenshots/screencasts if appropriate).
