### PR TITLE
Prototype: Breadcrumb tweaks

### DIFF
--- a/ons_alpha/articles/models.py
+++ b/ons_alpha/articles/models.py
@@ -30,6 +30,7 @@ class ArticlePage(BundledPageMixin, RoutablePageMixin, BasePage):
     template = "templates/pages/article_page.html"
     parent_page_types = ["ArticleSeriesPage"]
     subpage_types = []
+    show_in_breadcrumbs = False
 
     headline = models.CharField(max_length=255, blank=True)
     summary = models.TextField()
@@ -162,6 +163,7 @@ class ArticleSeriesPage(RoutablePageMixin, Page):
     subpage_types = ["ArticlePage"]
     preview_modes = []  # Disabling the preview mode due to it being a container page.
     page_description = "A container for Article series"
+    show_in_breadcrumbs = True
 
     content_panels = Page.content_panels + [
         HelpPanel(

--- a/ons_alpha/bulletins/models.py
+++ b/ons_alpha/bulletins/models.py
@@ -32,6 +32,7 @@ class BulletinPage(BundledPageMixin, RoutablePageMixin, BasePage):
     base_form_class = PageWithUpdatesAdminForm
     template = "templates/pages/bulletin_page.html"
     parent_page_types = ["BulletinSeriesPage"]
+    show_in_breadcrumbs = False
     subpage_types = []
 
     headline = models.CharField(max_length=255, blank=True)
@@ -170,6 +171,7 @@ class BulletinSeriesPage(RoutablePageMixin, Page):
     subpage_types = ["BulletinPage"]
     preview_modes = []  # Disabling the preview mode due to it being a container page.
     page_description = "A container for Bulletin series"
+    show_in_breadcrumbs = True
 
     content_panels = Page.content_panels + [
         HelpPanel(

--- a/ons_alpha/core/models/base.py
+++ b/ons_alpha/core/models/base.py
@@ -19,7 +19,6 @@ __all__ = [
 class BasePage(ListingFieldsMixin, SocialFieldsMixin, Page):
     show_in_menus_default = True
     show_in_breadcrumbs = True
-    link_in_breadcrumbs = True
 
     class Meta:
         abstract = True

--- a/ons_alpha/core/models/base.py
+++ b/ons_alpha/core/models/base.py
@@ -18,6 +18,8 @@ __all__ = [
 @method_decorator(get_default_cache_control_decorator(), name="serve")
 class BasePage(ListingFieldsMixin, SocialFieldsMixin, Page):
     show_in_menus_default = True
+    show_in_breadcrumbs = True
+    link_in_breadcrumbs = True
 
     class Meta:
         abstract = True

--- a/ons_alpha/jinja2/templates/components/navigation/breadcrumbs.html
+++ b/ons_alpha/jinja2/templates/components/navigation/breadcrumbs.html
@@ -1,25 +1,33 @@
-{% if page and page.get_ancestors()|length > 1 %}
-    {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 
-    {% set breadcrumbs=[] %}
+{% if page %}
+    {% set ancestors = page.get_ancestors().filter(depth__gt=1) %}
+    {% if ancestors|length %}
+        {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 
-    {% for ancestor_page in page.get_ancestors() %}
-        {% if not ancestor_page.is_root() %}
-            {% if ancestor_page.depth <= 2 %}
+        {% set breadcrumbs=[] %}
+
+        {% for item in ancestors %}
+            {% if item.depth == 2 %}
                 {% do breadcrumbs.append({"url": "/", "text": _("Home")}) %}
-            {% else %}
-                {% do breadcrumbs.append({"url": pageurl(ancestor_page), "text": ancestor_page.title}) %}
+            {% elif item.specific_class.show_in_breadcrumbs %}
+                {% if item.specific_class.link_in_breadcrumbs %}
+                    {% do breadcrumbs.append({"url": pageurl(item), "text": item.title}) %}
+                {% else %}
+                    {% do breadcrumbs.append({"text": item.title}) %}
+                {% endif %}
             {% endif %}
-        {% endif %}
-    {% endfor %}
+        {% endfor %}
 
-    {% do breadcrumbs.append({"text": page.title}) %}
-    {# fmt:off #}
-    {{
-        onsBreadcrumbs({
-            "ariaLabel": 'Breadcrumbs',
-            "itemsList": breadcrumbs
-        })
-    }}
+        {% if page.specific_class.show_in_breadcrumbs %}
+            {% do breadcrumbs.append({"text": page.title}) %}
+        {% endif %}
+        {# fmt:off #}
+        {{
+            onsBreadcrumbs({
+                "ariaLabel": 'Breadcrumbs',
+                "itemsList": breadcrumbs
+            })
+        }}
     {# fmt:on #}
+    {% endif %}
 {% endif %}

--- a/ons_alpha/jinja2/templates/components/navigation/breadcrumbs.html
+++ b/ons_alpha/jinja2/templates/components/navigation/breadcrumbs.html
@@ -10,24 +10,19 @@
             {% if item.depth == 2 %}
                 {% do breadcrumbs.append({"url": "/", "text": _("Home")}) %}
             {% elif item.specific_class.show_in_breadcrumbs %}
-                {% if item.specific_class.link_in_breadcrumbs %}
-                    {% do breadcrumbs.append({"url": pageurl(item), "text": item.title}) %}
-                {% else %}
-                    {% do breadcrumbs.append({"text": item.title}) %}
-                {% endif %}
+                {% do breadcrumbs.append({"text": item.title}) %}
             {% endif %}
         {% endfor %}
-
         {% if page.specific_class.show_in_breadcrumbs %}
             {% do breadcrumbs.append({"text": page.title}) %}
         {% endif %}
-        {# fmt:off #}
-        {{
-            onsBreadcrumbs({
-                "ariaLabel": 'Breadcrumbs',
-                "itemsList": breadcrumbs
-            })
-        }}
-    {# fmt:on #}
+            {# fmt:off #}
+            {{
+                onsBreadcrumbs({
+                    "ariaLabel": 'Breadcrumbs',
+                    "itemsList": breadcrumbs
+                })
+            }}
+        {# fmt:on #}
     {% endif %}
 {% endif %}

--- a/ons_alpha/topics/models.py
+++ b/ons_alpha/topics/models.py
@@ -190,4 +190,4 @@ class TopicSectionPage(BaseTopicPage):
     template = "templates/pages/topics/topic_section_page.html"
     subpage_types = ["topics.TopicSectionPage", "topics.TopicPage"]
     page_description = "General topic page. e.g. Economy"
-    link_in_breadcrumbs = False
+    show_in_breadcrumbs = False

--- a/ons_alpha/topics/models.py
+++ b/ons_alpha/topics/models.py
@@ -190,3 +190,4 @@ class TopicSectionPage(BaseTopicPage):
     template = "templates/pages/topics/topic_section_page.html"
     subpage_types = ["topics.TopicSectionPage", "topics.TopicPage"]
     page_description = "General topic page. e.g. Economy"
+    link_in_breadcrumbs = False


### PR DESCRIPTION
Allows pages to be hidden from breadcrumb links completely, or be included without a URL.

Have also variabalized the queryset in the template, so that we're not querying the database more than once - And am filtering the root page out, so that we don't need `{% if %}` cases for it.