### PR TITLE
Add back to top link at mobile, and tidy some bottom margins

### DIFF
--- a/ons_alpha/jinja2/templates/base_page.html
+++ b/ons_alpha/jinja2/templates/base_page.html
@@ -1,5 +1,6 @@
 {% extends "templates/base.html" %}
 {% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/back-to-top/_macro.njk" import onsBackToTop %}
 
 {% block meta %}
     {{ super() }}
@@ -59,6 +60,7 @@
                     {# This is the main tag in the base template in the design system #}
                     <div class="ons-page__main {{ mainColClasses }}">
                         {% block main %}{% endblock %}
+                        {{ onsBackToTop() }}
                     </div>
                 </div>
             </div>

--- a/ons_alpha/static_src/sass/components/_document-list-block.scss
+++ b/ons_alpha/static_src/sass/components/_document-list-block.scss
@@ -3,6 +3,12 @@
 .document-list-block {
     margin-bottom: rem-sizing(64);
 
+    /* stylelint-disable selector-class-pattern */
+    .block-document_list:last-child & {
+        margin-bottom: 0;
+    }
+    /* stylelint-enable selector-class-pattern */
+
     &__title {
         @include heading-2();
     }

--- a/ons_alpha/static_src/sass/components/_rich-text.scss
+++ b/ons_alpha/static_src/sass/components/_rich-text.scss
@@ -19,6 +19,10 @@
 
     p {
         margin-bottom: rem-sizing(32);
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 
     // Reduce bottom margin on elements in the corrections block

--- a/ons_alpha/static_src/sass/components/design_system_overrides/_back-to-top.scss
+++ b/ons_alpha/static_src/sass/components/design_system_overrides/_back-to-top.scss
@@ -1,0 +1,11 @@
+@use 'config' as *;
+
+// overrides to ons back-to-top styles
+.ons-back-to-top {
+    margin-top: rem-sizing(64);
+
+    // hide at desktop
+    @include media-query('m') {
+        display: none;
+    }
+}

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -17,6 +17,7 @@
 @use 'components/topic-header';
 
 // ONS design system overrides
+@use 'components/design_system_overrides/back-to-top';
 @use 'components/design_system_overrides/breadcrumbs';
 @use 'components/design_system_overrides/button';
 @use 'components/design_system_overrides/container';


### PR DESCRIPTION
### What is the context of this PR?
See https://jira.ons.gov.uk/browse/NWP-547
This pr adds the back to top link, for mobile only (easy to change to desktop too if we need to)

### How to review
Check the prototype pages at mobile to see the new back-to-top link in action.
