### PR TITLE
Layout tweak to topic and bulletin page to ensure main page contents …

### DIFF
--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -85,59 +85,57 @@
 {% endblock %}
 
 {% block main %}
-    <div class="ons-container">
-        <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
-            <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
-                {# fmt:off #}
-                {{-
-                    onsTableOfContents({
-                        "title": 'Contents',
-                        "ariaLabel": 'Sections in this page',
-                        "itemsList": toc
-                    })
-                }}
-                {# fmt:on #}
-            </div>
+    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
+        <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
+            {# fmt:off #}
+            {{-
+                onsTableOfContents({
+                    "title": 'Contents',
+                    "ariaLabel": 'Sections in this page',
+                    "itemsList": toc
+                })
+            }}
+            {# fmt:on #}
+        </div>
 
-            <div class="ons-grid__col ons-col-8@m">
-                {# if there are no contact details on the page, we don't want the last
-                streamfield block to have a bottom margin. last_flush is used in stream_block.html #}
-                {% if page.contact_details %}
-                    {% set last_flush = False %}
-                {% else %}
-                    {% set last_flush = True %}
-                {% endif %}
+        <div class="ons-grid__col ons-col-8@m">
+            {# if there are no contact details on the page, we don't want the last
+            streamfield block to have a bottom margin. last_flush is used in stream_block.html #}
+            {% if page.contact_details %}
+                {% set last_flush = False %}
+            {% else %}
+                {% set last_flush = True %}
+            {% endif %}
 
-                {% include_block page.body %}
+            {% include_block page.body %}
 
-                {% if page.contact_details %}
-                    <section id="contact-details">
-                        <h2 class="heading-2">{{ _("Contact details") }}</h2>
+            {% if page.contact_details %}
+                <section id="contact-details">
+                    <h2 class="heading-2">{{ _("Contact details") }}</h2>
 
-                        {% set contactDetailsMarkup %}
+                    {% set contactDetailsMarkup %}
+                        <p class="contact-details__line">
+                            <strong>Name</strong>: {{ page.contact_details.name }}
+                        </p>
+                        <p class="contact-details__line">
+                            <strong>Email</strong>: <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.email }}</a>
+                        </p>
+                        {% if page.contact_details.phone %}
                             <p class="contact-details__line">
-                                <strong>Name</strong>: {{ page.contact_details.name }}
-                            </p>
-                            <p class="contact-details__line">
-                                <strong>Email</strong>: <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.email }}</a>
-                            </p>
-                            {% if page.contact_details.phone %}
-                                <p class="contact-details__line">
-                                    <strong>Telephone</strong>: <a href="tel:{{ page.contact_details.phone | replace(' ','')}}">{{ page.contact_details.phone }}</a>
+                                <strong>Telephone</strong>: <a href="tel:{{ page.contact_details.phone | replace(' ','')}}">{{ page.contact_details.phone }}</a>
 
-                                </p>
-                            {% endif %}
-                        {% endset %}
-                        {# fmt:off #}
-                        {{-
-                            onsTextIndent({
-                                "text": contactDetailsMarkup
-                            })
-                        -}}
-                        {# fmt:on #}
-                    </section>
-                {% endif %}
-            </div>
+                            </p>
+                        {% endif %}
+                    {% endset %}
+                    {# fmt:off #}
+                    {{-
+                        onsTextIndent({
+                            "text": contactDetailsMarkup
+                        })
+                    -}}
+                    {# fmt:on #}
+                </section>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/ons_alpha/jinja2/templates/pages/topics/topic_page.html
+++ b/ons_alpha/jinja2/templates/pages/topics/topic_page.html
@@ -37,88 +37,86 @@
 {% block main %}
 
     {% if page.toc %}
-        <div class="ons-container">
-            <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
-                <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
-                    {# fmt:off #}
-                    {{-
-                        onsTableOfContents({
-                            "title": 'Contents',
-                            "ariaLabel": 'Sections in this page',
-                            "itemsList": page.toc
-                        })
-                    }}
-                    {# fmt:on #}
-                </div>
+        <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--32">
+            <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m">
+                {# fmt:off #}
+                {{-
+                    onsTableOfContents({
+                        "title": 'Contents',
+                        "ariaLabel": 'Sections in this page',
+                        "itemsList": page.toc
+                    })
+                }}
+                {# fmt:on #}
+            </div>
 
-                <div class="ons-grid__col ons-col-8@m">
-                    {% if page.body %}
-                        {% include_block page.body %}
-                    {% else %}
-                        {% if page.sections %}
+            <div class="ons-grid__col ons-col-8@m">
+                {% if page.body %}
+                    {% include_block page.body %}
+                {% else %}
+                    {% if page.sections %}
+                        {# fmt:off #}
+                        {{-
+                            onsPanel({
+                                "body": '<p>Currently we show the latest bulletin and articles per series, and the last five methodology pages ordered by the last review date</p>'
+                            })
+                        }}
+                        {# fmt:on #}
+                        <br />
+
+                        {% for section_title, section_items in page.sections.items() %}
+                            <section id="{{ section_title|slugify() }}">
+                                <h2>{{ section_title }}</h2>
+
+                                <div class="ons-timeline">{# done as markup as onsTimeline() errors even with the example in the DS #}
+                                    {% for item in section_items %}
+                                        <div class="ons-timeline__item">
+                                            <h2 class="ons-timeline__heading">
+                                                <a href="{{ pageurl(item) }}">{{ item.full_title or item.title }}</a>
+                                            </h2>
+                                            <div class="ons-timeline__content">
+                                                <p>{{ item.summary }}</p>
+                                            </div>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </section>
+                        {% endfor %}
+                    {% endif %}
+
+                    {% if page.related_by_topic %}
+                        <section id="related">
+                            <h2>{{ _("Related content") }}</h2>
+                            <p>{% trans topic=page.topic %}This sections surfaces content tagged with "{{ topic }}"{% endtrans %}</p>
+
+                            {% set rows=[] %}
+                            {% for type, items in page.related_by_topic.items() %}
+                                {% set items_list=[] %}
+                                {% for item in items %}
+                                    {% do items_list.append({"url": pageurl(item), "text": item.full_title or item.title}) %}
+                                {% endfor %}
+                                {# fmt:off #}
+                                {%
+                                    do rows.append({
+                                        "id": "related-content-" + type|slugify(),
+                                        "title": type,
+                                        "itemsList": items_list
+                                    })
+                                %}
+                                {# fmt:on #}
+                            {% endfor %}
+
                             {# fmt:off #}
-                            {{-
-                                onsPanel({
-                                    "body": '<p>Currently we show the latest bulletin and articles per series, and the last five methodology pages ordered by the last review date</p>'
+                            {{
+                                onsRelatedContent({
+                                    "ariaLabel": 'Related content',
+                                    "rows": rows
                                 })
                             }}
                             {# fmt:on #}
-                            <br />
-
-                            {% for section_title, section_items in page.sections.items() %}
-                                <section id="{{ section_title|slugify() }}">
-                                    <h2>{{ section_title }}</h2>
-
-                                    <div class="ons-timeline">{# done as markup as onsTimeline() errors even with the example in the DS #}
-                                        {% for item in section_items %}
-                                            <div class="ons-timeline__item">
-                                                <h2 class="ons-timeline__heading">
-                                                    <a href="{{ pageurl(item) }}">{{ item.full_title or item.title }}</a>
-                                                </h2>
-                                                <div class="ons-timeline__content">
-                                                    <p>{{ item.summary }}</p>
-                                                </div>
-                                            </div>
-                                        {% endfor %}
-                                    </div>
-                                </section>
-                            {% endfor %}
-                        {% endif %}
-
-                        {% if page.related_by_topic %}
-                            <section id="related">
-                                <h2>{{ _("Related content") }}</h2>
-                                <p>{% trans topic=page.topic %}This sections surfaces content tagged with "{{ topic }}"{% endtrans %}</p>
-
-                                {% set rows=[] %}
-                                {% for type, items in page.related_by_topic.items() %}
-                                    {% set items_list=[] %}
-                                    {% for item in items %}
-                                        {% do items_list.append({"url": pageurl(item), "text": item.full_title or item.title}) %}
-                                    {% endfor %}
-                                    {# fmt:off #}
-                                    {%
-                                        do rows.append({
-                                            "id": "related-content-" + type|slugify(),
-                                            "title": type,
-                                            "itemsList": items_list
-                                        })
-                                    %}
-                                    {# fmt:on #}
-                                {% endfor %}
-
-                                {# fmt:off #}
-                                {{
-                                    onsRelatedContent({
-                                        "ariaLabel": 'Related content',
-                                        "rows": rows
-                                    })
-                                }}
-                                {# fmt:on #}
-                            </section>
-                        {% endif %}
+                        </section>
                     {% endif %}
-                </div>
+                {% endif %}
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
### What is the context of this PR?
See https://jira.ons.gov.uk/browse/NWP-546 - feedback from Joe N on alignment.

The issue is actually the `ons-container` div on both the topic and bulletin page, which is adding extra padding. This MR looks complex because of re-indenting but is just removing that one div on both pages.

### How to review
Describe the steps required to test the changes (include screenshots/screencasts if appropriate).

### Screenshots
<details>
<summary>Click and ye shall find</summary>

Topic page before:

![Screenshot 2024-11-13 at 12 18 02](https://github.com/user-attachments/assets/35ee6efe-0e85-40bc-80c9-5bde342ec0e3)

Topic page after:

![Screenshot 2024-11-13 at 12 17 49](https://github.com/user-attachments/assets/b12d51c8-3cbb-47f3-82ae-8678c43cf9de)

</details>
