### PR TITLE
Use grid to lay out the content in the bulletin header so it reflows correctly at mobile and desktop

### DIFF
--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -29,44 +29,39 @@
         </div>
 
         {% block release_meta %}
-            <div class="ons-container">
-                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Release date") }}:</span>
-                        <span class="ons-u-nowrap">{{ page.release_date|date("j F Y") }}</span>
-                    </div>
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Version") }}:</span>
-                        {% if latest_version_url %}
-                            <span>{{ _("This has been superseded.") }} <a href="{{ latest_version_url }}">{{ _("View corrected version") }}</a></span>
-                        {% else %}
-                            <span class="ons-u-nowrap">{{ _("Latest") }}</span>
-                        {% endif %}
-                    </div>
-                    <div class="ons-grid__col ons-col-4@m">
-                        {% if page.contact_details %}
-                            <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Contact") }}:</span>
-                            <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
-                        {% endif %}
-                    </div>
+            <div class="ons-container bulletin-header__releases">
+                <div>
+                    <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Release date") }}:</span>
+                    <span class="ons-u-nowrap">{{ page.release_date|date("j F Y") }}</span>
                 </div>
-                <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--40 bulletin-header__releases">
-                    <div class="ons-grid__col ons-col-4@m">
-                        {% if page.next_release_date %}
-                            <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Next release") }}:</span>
-                            <span class="ons-u-nowrap">{{ page.next_release_date|date("j F Y") }}</span>
-                        {% endif %}
+                {% if page.next_release_date %}
+                    <div>
+                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Next release") }}:</span>
+                        <span class="ons-u-nowrap">{{ page.next_release_date|date("j F Y") }}</span>
                     </div>
-                    <div class="ons-grid__col ons-col-4@m">
-                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Releases") }}:</span>
-                        {% if page.is_latest %}
-                            <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
-                        {% else %}
-                            <a href="{{  routablepageurl(page.get_parent().specific, "latest_release") }}">{{ _("View latest release") }}</a>
-                        {% endif %}
-                    </div>
-                    <div class="ons-grid__col ons-col-4@m"></div>
+                {% endif %}
+                <div>
+                    <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Version") }}:</span>
+                    {% if latest_version_url %}
+                        <span>{{ _("This has been superseded.") }} <a href="{{ latest_version_url }}">{{ _("View corrected version") }}</a></span>
+                    {% else %}
+                        <span class="ons-u-nowrap">{{ _("Latest") }}</span>
+                    {% endif %}
                 </div>
+                <div>
+                    <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Releases") }}:</span>
+                    {% if page.is_latest %}
+                        <a href="{{ routablepageurl(page.get_parent().specific, "previous_releases") }}">{{ _("View previous releases") }}</a>
+                    {% else %}
+                        <a href="{{  routablepageurl(page.get_parent().specific, "latest_release") }}">{{ _("View latest release") }}</a>
+                    {% endif %}
+                </div>
+                {% if page.contact_details %}
+                    <div>
+                        <span class="ons-u-fs-r--b bulletin-header__releases-label">{{ _("Contact") }}:</span>
+                        <a href="mailto:{{ page.contact_details.email }}">{{ page.contact_details.name }}</a>
+                    </div>
+                {% endif %}
             </div>
         {% endblock %}
     </div>

--- a/ons_alpha/static_src/sass/components/_bulletin-header.scss
+++ b/ons_alpha/static_src/sass/components/_bulletin-header.scss
@@ -82,8 +82,15 @@
     }
 
     &__releases {
+        display: grid;
+        column-gap: rem-sizing(40);
         row-gap: rem-sizing(8);
-        margin-bottom: rem-sizing(8);
+
+        @include media-query('l') {
+            grid-template-rows: 1fr 1fr;
+            grid-template-columns: 1fr 1fr 1fr;
+            grid-auto-flow: column;
+        }
     }
 
     &__releases-label {


### PR DESCRIPTION
### What is the context of this PR?
See https://jira.ons.gov.uk/browse/NWP-548

The mobile layout of the data using a flex layout was incorrect. This uses a grid layout instead.

### How to review
Review a bulletin page and compare the meta data in the header to the designs at mobile and desktop

### Screen recordings

<details>
<summary>Look inside the eye of your mind</summary>

Before:
https://github.com/user-attachments/assets/000abd3a-d384-43c0-b8de-69bffa7a7e2b

After:
https://github.com/user-attachments/assets/b3f6b7c0-abd7-4175-bf3e-cd396e984485


</details>


