### PR TITLE
Front end styling for the chart on the topic page

### DIFF
--- a/ons_alpha/core/blocks/featured_document.py
+++ b/ons_alpha/core/blocks/featured_document.py
@@ -77,6 +77,6 @@ class FeaturedDocumentWithChartBlock(FeaturedDocumentBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         page = value["page"].specific
-        context["link_title"] = page.title
+        context["link_title"] = page.headline or page.title
         context["link_url"] = page.get_url(parent_context.get("request") if parent_context else None)
         return context

--- a/ons_alpha/core/blocks/featured_document.py
+++ b/ons_alpha/core/blocks/featured_document.py
@@ -58,8 +58,8 @@ class FeaturedDocumentBlock(blocks.StructBlock):
 
 
 class FeaturedDocumentWithChartBlock(FeaturedDocumentBlock):
-    chart_title = blocks.CharBlock(label=_("Chart title"), required=True)
     chart_url = blocks.URLBlock(label=_("Chart URL"), required=True)
+    chart_release_date = blocks.DateBlock(label=_("Release date"), required=True)
     chart_initial_height = blocks.IntegerBlock(
         label="Initial chart height (px)",
         help_text=("NOTE: The chart embed will remain at this height when JS is disabled."),
@@ -70,15 +70,13 @@ class FeaturedDocumentWithChartBlock(FeaturedDocumentBlock):
     )
 
     class Meta:
-        icon = "list-ul"
+        icon = "code"
         label = _("Featured document (with chart)")
-        template = "templates/components/streamfield/featured_document_block.html"
+        template = "templates/components/streamfield/featured_chart_block.html"
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        context["documents"][0]["chart"] = {
-            "title": value["chart_title"],
-            "embedUrl": value["chart_url"],
-            "imageUrl": value["chart_image_url"],
-        }
+        page = value["page"].specific
+        context["link_title"] = page.title
+        context["link_url"] = page.get_url(parent_context.get("request") if parent_context else None)
         return context

--- a/ons_alpha/core/blocks/featured_document.py
+++ b/ons_alpha/core/blocks/featured_document.py
@@ -59,7 +59,14 @@ class FeaturedDocumentBlock(blocks.StructBlock):
 
 class FeaturedDocumentWithChartBlock(FeaturedDocumentBlock):
     chart_url = blocks.URLBlock(label=_("Chart URL"), required=True)
-    chart_release_date = blocks.DateBlock(label=_("Release date"), required=True)
+    chart_title = blocks.CharBlock(
+        label=_("Chart title"),
+        required=True,
+        help_text="""
+            Detailed chart title, e.g.
+            'Value sales, monthly percentage change, seasonally adjusted, Great Britain, July 2024'
+            """,
+    )
     chart_initial_height = blocks.IntegerBlock(
         label="Initial chart height (px)",
         help_text=("NOTE: The chart embed will remain at this height when JS is disabled."),
@@ -77,6 +84,11 @@ class FeaturedDocumentWithChartBlock(FeaturedDocumentBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         page = value["page"].specific
-        context["link_title"] = page.headline or page.title
+        context["link_title"] = page.headline or page.display_title
         context["link_url"] = page.get_url(parent_context.get("request") if parent_context else None)
+        if release_date := getattr(page, "release_date", None):
+            context["release_date"] = {
+                "iso": release_date.isoformat(),
+                "short": release_date.strftime("%-d %B %Y"),
+            }
         return context

--- a/ons_alpha/jinja2/templates/components/streamfield/featured_chart_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/featured_chart_block.html
@@ -25,6 +25,7 @@ The appearance is similar to the featured document in the document list block, b
         <div data-chart-iframe
              id="featured-chart-id"
              data-url="{{ value.chart_url }}"
+             data-title="{{ link_title }}"
              class="featured-chart__embed-container">
             <iframe src="{{ value.chart_url }}"
                     title="{{ value.title }}"

--- a/ons_alpha/jinja2/templates/components/streamfield/featured_chart_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/featured_chart_block.html
@@ -7,15 +7,18 @@ The appearance is similar to the featured document in the document list block, b
     <h2 class="heading-2">{{ heading }}</h2>
 
     <div class="featured-chart__item">
-        <h3 class="ons-u-fs-m ons-u-mt-no ons-u-mb-2xs">
+        <h3 class="ons-u-fs-m ons-u-mt-no ons-u-mb-m">
             <a href="{{ link_url }}">
                 {{ link_title }}
             </a>
         </h3>
+        <h4 class="heading-4">{{ value.chart_title }}</h4>
         <ul class="featured-chart__metadata">
             <li class="featured-chart__item-attribute ons-u-fs-s">
                 <span class="ons-u-fw-b">Released:</span>
-                <time datetime="2024-10-18">{{ value.chart_release_date }}</time>
+                {%- if release_date -%}
+                    <time datetime="{{ release_date.iso }}">{{ release_date.short }}</time>
+                {%- endif -%}
             </li>
             <li class="featured-chart__item-attribute ons-u-fs-s">
                 <span class="ons-u-fw-b">{{ value.content_type_label }}</span>
@@ -25,10 +28,10 @@ The appearance is similar to the featured document in the document list block, b
         <div data-chart-iframe
              id="featured-chart-id"
              data-url="{{ value.chart_url }}"
-             data-title="{{ link_title }}"
+             data-title="{{ value.chart_title }}"
              class="featured-chart__embed-container">
             <iframe src="{{ value.chart_url }}"
-                    title="{{ value.title }}"
+                    title="{{ value.chart_title }}"
                     width="100%"
                     height="{{ value.chart_initial_height }}">
             </iframe>

--- a/ons_alpha/jinja2/templates/components/streamfield/featured_chart_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/featured_chart_block.html
@@ -1,0 +1,40 @@
+{#
+This is the template for the FeaturedDocumentWithChart block.
+The appearance is similar to the featured document in the document list block, but although the back-end block code inherits from FeaturedDocumentList, the front-end here is different enough to create its own markup and avoid customising the document-list macro.
+ #}
+
+<section id="{{ slug }}" class="featured-chart">
+    <h2 class="heading-2">{{ heading }}</h2>
+
+    <div class="featured-chart__item">
+        <h3 class="ons-u-fs-m ons-u-mt-no ons-u-mb-2xs">
+            <a href="{{ link_url }}">
+                {{ link_title }}
+            </a>
+        </h3>
+        <ul class="featured-chart__metadata">
+            <li class="featured-chart__item-attribute ons-u-fs-s">
+                <span class="ons-u-fw-b">Released:</span>
+                <time datetime="2024-10-18">{{ value.chart_release_date }}</time>
+            </li>
+            <li class="featured-chart__item-attribute ons-u-fs-s">
+                <span class="ons-u-fw-b">{{ value.content_type_label }}</span>
+            </li>
+        </ul>
+
+        <div data-chart-iframe
+             id="featured-chart-id"
+             data-url="{{ value.chart_url }}"
+             class="featured-chart__embed-container">
+            <iframe src="{{ value.chart_url }}"
+                    title="{{ value.title }}"
+                    width="100%"
+                    height="{{ value.chart_initial_height }}">
+            </iframe>
+        </div>
+
+        <div class="featured-chart__item-description">
+            {{ value.description }}
+        </div>
+    </div>
+</section>

--- a/ons_alpha/jinja2/templates/pages/topics/topic_page.html
+++ b/ons_alpha/jinja2/templates/pages/topics/topic_page.html
@@ -123,3 +123,8 @@
         </div>
     {% endif %}
 {% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script src="{{ static('js/third-party/pym.min.js') }}"></script>
+{% endblock %}

--- a/ons_alpha/static_src/sass/components/_featured-chart.scss
+++ b/ons_alpha/static_src/sass/components/_featured-chart.scss
@@ -1,0 +1,41 @@
+@use 'config' as *;
+
+// Uses similar styles to the featured document block
+// Does not use flex display as it messes up the iframe resize for pym
+
+.featured-chart {
+    margin-bottom: rem-sizing(64);
+
+    &__item {
+        background-color: var(--ons-color-banner-bg);
+        outline: 2px solid transparent; // for high contrast mode
+        outline-offset: -2px;
+        padding: rem-sizing(32);
+    }
+
+    &__metadata {
+        padding: 0;
+        margin: 0;
+    }
+
+    &__item-attribute {
+        color: var(--ons-color-text-metadata);
+        display: inline-block;
+        margin: 0 1rem 0 0;
+    }
+
+    &__item-description {
+        margin-bottom: 0;
+        max-width: 660px;
+
+        p:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+
+    &__embed-container {
+        padding-top: rem-sizing(32);
+        border-bottom: 1px solid var(--ons-color-grey-35);
+        margin-bottom: rem-sizing(32);
+    }
+}

--- a/ons_alpha/static_src/sass/main.scss
+++ b/ons_alpha/static_src/sass/main.scss
@@ -8,6 +8,7 @@
 @use 'components/document-list-block';
 @use 'components/chart-embed';
 @use 'components/contact-details';
+@use 'components/featured-chart';
 @use 'components/headline-figures';
 @use 'components/landing-header';
 @use 'components/navigation';


### PR DESCRIPTION
### What is the context of this PR?
- Builds on https://github.com/ONSdigital/dis-wagtail-alpha/pull/126 (note this branch targets that branch so changes are clear)
- Adds a custom front-end template for the featured document + chart block on the topic page
- Adds pym.js to the topic page
- Makes some tweaks to the back-end code to make the context vars simpler, as we're no longer using the document block macro template for this

### To consider / notes
- I think we could consider renaming the block to FeaturedChart but have left it as-is for now
- The overall heading is hard-coded as 'featured' - it looks from the design that this is intended instead of the featured document block - we could potentially simplify and combine these blocks into one.

### How to review
- Test with the relevant chart embed on the topic page - https://www.ons.gov.uk/visualisations/dvc3082/fig01_featured/index.html
- You can also now test the fallback image as datavis have updated the embed to include one.

### Screenshot

<details>
    <summary>Open sesame</summary>

<img width="788" alt="Screenshot 2024-11-14 at 14 28 48" src="https://github.com/user-attachments/assets/278515a2-c4e8-4b18-a09c-0e7f7007209b">

</details>
