### PR TITLE
Update page titles

### DIFF
--- a/ons_alpha/bulletins/models.py
+++ b/ons_alpha/bulletins/models.py
@@ -112,8 +112,12 @@ class BulletinPage(BundledPageMixin, RoutablePageMixin, BasePage):
     ]
 
     @property
+    def display_title(self):
+        return f"{self.get_parent().title}: {self.title}"
+
+    @property
     def full_title(self):
-        return self.headline.strip() or f"{self.get_parent().title}: {self.title}"
+        return self.headline.strip() or self.display_title
 
     @property
     def is_latest(self):

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -90,11 +90,17 @@
     {% set body_class = '' %}
 {% endif %}
 
+{%- set page_title -%}
+    {%- with current_site=wagtail_site() -%}
+        {% if current_site and page.pk == current_site.root_page.pk and current_site.site_name %}{{ current_site.site_name }} - {% endif %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.display_title | default(page.title) }}{% endif %}{% if current_site and page.pk != current_site.root_page.pk and current_site.site_name %} - {{ current_site.site_name }}{% endif %}
+    {%- endwith -%}
+{%- endset -%}
+
 {# navlinks are hard-code for the prototype #}
 {% set pageConfig = {
     "bodyClasses": body_class,
+    "title": page_title,
     "header": {
-        "title": page_title,
         "phase": {
             "badge": 'Alpha',
             "html": 'This is a new service. To help us improve it, ' + feedbackLink
@@ -326,10 +332,6 @@
 }
 %}
 {# fmt:on #}
-
-{% set page_title %}
-    {% if current_site and page.pk == current_site.root_page.pk and current_site.site_name %}{{ current_site.site_name }} | {% endif %}{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title}}{% endif %}{% endblock %}{% block title_suffix %}{% if current_site and page.pk != current_site.root_page.pk and current_site.site_name %} | {{ current_site.site_name }}{% endif %}{% endblock %}
-{% endset %}
 
 {% block preHeader %}
     {# Use same logic as the header to determine the correct language #}

--- a/ons_alpha/jinja2/templates/pages/previous_releases.html
+++ b/ons_alpha/jinja2/templates/pages/previous_releases.html
@@ -4,7 +4,7 @@
     <h1>Previous Releases</h1>
     <ul>
         {% for page in pages %}
-            <li><a href="{{ pageurl(page) }}">{{ page.title }}</a> - {{ page.release_date }}</li>
+            <li><a href="{{ pageurl(page) }}">{{ page.display_title | default(page.title) }}</a> - {{ page.release_date }}</li>
         {% else %}
             <p>{{ _("There are currently no releases") }}</p>
         {% endfor %}


### PR DESCRIPTION
### What is the context of this PR?
Small tweak to accommodate:
- All page titles should be suffixed with `- Office for National Statistics` (except home?)
- Wherever the bulletin title is displayed, it should be prefixed with the series name.

### How to review
- Ensure page title includes the site name
- Bulletins page title should include the series name
- Previous releases listing should include the series name