### PR TITLE
Update wording on cookie page

### DIFF
--- a/ons_alpha/jinja2/templates/pages/manage_cookie_settings.html
+++ b/ons_alpha/jinja2/templates/pages/manage_cookie_settings.html
@@ -123,7 +123,6 @@
                             "id": "cookies-measure-website-use",
                             "name": "cookies-usage",
                             "legend": "Do you want to allow usage tracking?",
-                            "legendClasses": "ons-u-vh",
                             "radios": [
                                 {
                                     "id": "on-1",
@@ -162,7 +161,6 @@
                         "id": "cookies-measure-website-settings",
                         "name": "cookies-settings",
                         "legend": "Do you want to allow settings?",
-                        "legendClasses": "ons-u-vh",
                         "radios": [
                             {
                                 "id": "on-3",


### PR DESCRIPTION
### What is the context of this PR?
See https://jira.ons.gov.uk/browse/NWP-550
The wording that was flagged as missing was a visually hidden legend above the radio buttons. This change makes it visible to all users.

### How to review
On your local build, visit http://localhost:8000/manage-cookie-settings/ and check you can see the legend above both sets of radio buttons

### Screenshots

<details>
<summary>
Click to see screenshots
</summary>


![Screenshot 2024-11-19 at 11 44 43](https://github.com/user-attachments/assets/de09251d-93d5-4a2c-b2eb-4457504023b2)

![Screenshot 2024-11-19 at 11 44 51](https://github.com/user-attachments/assets/7f602ab7-dfe1-486d-bbd6-f3719393a798)


</details>