### PR TITLE
Add a new setting for the CPI page url

### DIFF
--- a/ons_alpha/core/context_processors.py
+++ b/ons_alpha/core/context_processors.py
@@ -12,6 +12,7 @@ def global_vars(request):
         "LANGUAGE_CODE": settings.LANGUAGE_CODE,
         "IS_EXTERNAL_ENV": settings.IS_EXTERNAL_ENV,
         "TOPIC_PAGE_URL": settings.ONS_TOPIC_PAGE_URL,
+        "CPI_PAGE_URL": settings.ONS_CPI_PAGE_URL,
         "COOKIE_BANNER_ENABLED": settings.ONS_COOKIE_BANNER_ENABLED,
         "COOKIE_BANNER_SERVICE_NAME": settings.ONS_COOKIE_BANNER_SERVICE_NAME or request.get_host(),
         "MANAGE_COOKIE_SETTINGS_URL": reverse("manage-cookie-settings"),

--- a/ons_alpha/jinja2/templates/base.html
+++ b/ons_alpha/jinja2/templates/base.html
@@ -294,7 +294,7 @@
                                 },
                                 {
                                     "text": "Inflation and price indices",
-                                    "url": False,
+                                    "url": CPI_PAGE_URL,
                                 },
                                 {
                                     "text": "National accounts",

--- a/ons_alpha/settings/base.py
+++ b/ons_alpha/settings/base.py
@@ -829,6 +829,7 @@ SLACK_NOTIFICATIONS_WEBHOOK_URL = env.get("SLACK_NOTIFICATIONS_WEBHOOK_URL")
 SHORT_DATETIME_FORMAT = "d/m/Y P"
 
 ONS_TOPIC_PAGE_URL = env.get("ONS_TOPIC_PAGE_URL", "/business-industry-trade/retail-industry/")
+ONS_CPI_PAGE_URL = env.get("ONS_CPI_PAGE_URL", "")
 ONS_API_DATASET_BASE_URL = env.get("ONS_API_DATASET_BASE_URL", "https://api.beta.ons.gov.uk/v1/datasets")
 ONS_WEBSITE_DATASET_BASE_URL = env.get("ONS_WEBSITE_DATASET_BASE_URL", "https://www.ons.gov.uk/datasets")
 ONS_COOKIE_BANNER_ENABLED = env.get("ONS_COOKIE_BANNER_ENABLED", "false").lower() == "true"


### PR DESCRIPTION
### What is the context of this PR?
- Adds a new link in the navigation menu to the CPI page
- Relies on a new environment variable called `ONS_CPI_PAGE_URL` - added to both [staging](https://dashboard.heroku.com/apps/ons-nov-prototype-staging/settings) and [production](https://dashboard.heroku.com/apps/ons-nov-prototype-production/settings) heroku environments. These will need updating once the relevant page is published on staging or production.
- If the env var is not set, the link will not appear in the navigation.


### How to review
- You can test by setting an environment variable in your `.env` file and then stopping and starting the container, for example `ONS_CPI_PAGE_URL="https://www.ons.gov.uk/economy/inflationandpriceindices/"`
- You should see a link in the navigation menu to this url on the "Inflation and price indices" nav item.
