### PR TITLE
Headline facts and figures - update to min 3 max 6, and adjust layout

### DIFF
--- a/ons_alpha/core/blocks/headline_figures.py
+++ b/ons_alpha/core/blocks/headline_figures.py
@@ -12,7 +12,7 @@ class HeadlineFiguresItemBlock(StructBlock):
 class HeadlineFiguresBlock(ListBlock):
     def __init__(self, search_index=True, **kwargs):
         kwargs.setdefault("min_num", 3)
-        kwargs.setdefault("max_num", 3)
+        kwargs.setdefault("max_num", 6)
         super().__init__(HeadlineFiguresItemBlock, search_index=search_index, **kwargs)
 
     class Meta:

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -1,24 +1,22 @@
 <div class="ons-container headline-figures">
     <h2 class="headline-figures__heading ons-u-fs-l">Headline facts and figures</h2>
-    <div class="ons-grid ons-grid-flex-gap ons-grid-flex-gap--24 headline-figures__grid">
+    <div class="headline-figures__grid headline-figures__grid--{{ value|length }}">
         {% for figure in value %}
-            <div class="ons-grid__col">
-                <div class="headline-figures__block">
-                    <h3 class="headline-figures__title">
-                        {% if figure.title_link %}
-                            <a href="{{ pageurl(figure.title_link) }}">
-                        {% endif %}
-                        {{ figure.title }}
-                        {% if figure.title_link %}
-                            </a>
-                        {% endif %}
-                    </h3>
-                    <p class="headline-figures__figure">{{ figure.figure }}</p>
-
-                    {% if figure.supporting_text %}
-                        <p class="headline-figures__supporting-text ons-u-fs-r">{{ figure.supporting_text }}</p>
+            <div class="headline-figures__block">
+                <h3 class="headline-figures__title">
+                    {% if figure.title_link %}
+                        <a href="{{ pageurl(figure.title_link) }}">
                     {% endif %}
-                </div>
+                    {{ figure.title }}
+                    {% if figure.title_link %}
+                        </a>
+                    {% endif %}
+                </h3>
+                <p class="headline-figures__figure">{{ figure.figure }}</p>
+
+                {% if figure.supporting_text %}
+                    <p class="headline-figures__supporting-text ons-u-fs-r">{{ figure.supporting_text }}</p>
+                {% endif %}
             </div>
         {% endfor %}
     </div>

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -1,11 +1,36 @@
 @use 'config' as *;
 
 .headline-figures {
-    //padding-top: rem-sizing(24);
+    $root: &;
     padding-bottom: rem-sizing(40);
 
     &__grid {
-        row-gap: rem-sizing(24);
+        gap: rem-sizing(24);
+        display: grid;
+
+        &--3 {
+            @include media-query('m') {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
+
+        &--4 {
+            @include media-query('m') {
+                grid-template-columns: 1fr 1fr;
+            }
+        }
+
+        &--5 {
+            @include media-query('m') {
+                grid-template-columns: repeat(6, 1fr);
+            }
+        }
+
+        &--6 {
+            @include media-query('m') {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
     }
 
     &__block {
@@ -23,6 +48,18 @@
 
         @media (forced-colors: active) {
             border: 1px solid var(--ons-color-grey-5);
+        }
+
+        #{$root}__grid--5 & {
+            @include media-query('m') {
+                grid-column: span 3;
+            }
+        }
+
+        #{$root}__grid--5 &:nth-child(n + 3) {
+            @include media-query('m') {
+                grid-column: span 2;
+            }
         }
     }
 


### PR DESCRIPTION
### What is the context of this PR?
- Allows between 3 and 6 headline facts and figures on either the topic page or the article page
- Updates the layout at desktop:
   ```
   XXX
  ```
  ```
  XX
  XX
  ```
  ```
  X X
  XXX
  ```
   ```
   XX
   XX
   ```

### How to review
Try a varying number of headline facts and figures on a topic page and an article page:

<details><summary>Screencast below</summary>
https://github.com/user-attachments/assets/8cdfdd64-788b-4353-bc2b-add8460c2f0c
</details>

