### PR TITLE
NWP-584 Explore More StreamField block

### DIFF
--- a/ons_alpha/core/blocks/__init__.py
+++ b/ons_alpha/core/blocks/__init__.py
@@ -1,6 +1,7 @@
 from .button_link import ButtonLinkBlock
 from .document_list import DocumentListBlock
 from .embeddable import DocumentBlock, DocumentsBlock, ImageBlock, ONSChartEmbedBlock, ONSEmbedBlock
+from .explore_more import ExploreMoreBlock
 from .featured_document import FeaturedDocumentBlock, FeaturedDocumentWithChartBlock
 from .headline_figures import HeadlineFiguresBlock
 from .markup import HeadingBlock, ONSTableBlock, QuoteBlock, TableBlock, TypedTableBlock
@@ -13,6 +14,7 @@ __all__ = [
     "CorrectionBlock",
     "DocumentBlock",
     "DocumentListBlock",
+    "ExploreMoreBlock",
     "FeaturedDocumentBlock",
     "FeaturedDocumentWithChartBlock",
     "HeadingBlock",

--- a/ons_alpha/core/blocks/explore_more.py
+++ b/ons_alpha/core/blocks/explore_more.py
@@ -1,0 +1,71 @@
+from django.utils.html import format_html, strip_tags
+from django.utils.text import slugify
+from django.utils.translation import gettext as _
+from wagtail.blocks import (
+    CharBlock,
+    ListBlock,
+    StructBlock,
+    TextBlock,
+)
+from wagtail.images.blocks import ImageChooserBlock
+
+
+class ExploreMoreListItemBlock(StructBlock):
+    title = CharBlock(label=_("Title"), max_length=200, required=True)
+    thumbnail = ImageChooserBlock(label=_("Thumbnail"), required=True)
+    description = TextBlock(label=_("Description"), max_length=300, required=True)
+
+    class Meta:
+        icon = "list-ul"
+        label = _("Explore more item")
+
+    def clean(self, value):
+        value = super().clean(value)
+        value["description"] = strip_tags(value["description"])
+        return value
+
+
+class ExploreMoreBlock(StructBlock):
+    """Variant of DocumentListBlock that includes thumbnails, and no metadata.
+
+    Both use the same DS Document List Block template and macro.
+    """
+
+    heading = CharBlock(label=_("Heading"), max_length=200, required=True)
+    documents = ListBlock(ExploreMoreListItemBlock, label=_("Documents"))
+
+    class Meta:
+        icon = "list-ul"
+        label = _("Explore more")
+        template = "templates/components/streamfield/document_list_block.html"
+
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context=parent_context)
+        context["heading"] = value["heading"]
+        context["slug"] = slugify(value["heading"])
+
+        # Prepare 'documents' list for the context
+        documents = []
+        for item in value["documents"]:
+            document = {
+                "title": {
+                    "text": item["title"],
+                },
+                "description": format_html("<p>{}</p>", item["description"]),
+                "metadata": {},
+                "thumbnail": {
+                    # standard: 136×96
+                    # high-dpi: 192×272
+                    "smallSrc": item["thumbnail"].get_rendition("fill-136x96").url,
+                    "largeSrc": item["thumbnail"].get_rendition("fill-192x272").url,
+                },
+            }
+            documents.append(document)
+
+        # Add 'documents' to the context
+        context["documents"] = documents
+
+        return context
+
+    def to_table_of_contents_items(self, value):
+        return [{"url": "#" + slugify(value["heading"]), "text": value["heading"]}]

--- a/ons_alpha/core/blocks/stream_blocks.py
+++ b/ons_alpha/core/blocks/stream_blocks.py
@@ -8,7 +8,6 @@ from ons_alpha.core.blocks import (
     CorrectionBlock,
     DocumentListBlock,
     DocumentsBlock,
-    ExploreMoreBlock,
     HeadingBlock,
     NoticeBlock,
     ONSChartEmbedBlock,
@@ -50,7 +49,6 @@ class CoreStoryBlock(StreamBlock):
         "Use the 'ONS Table' block for the full ONS needs.",
     )
     document_list = DocumentListBlock()
-    explore_more = ExploreMoreBlock()
 
     class Meta:
         block_counts = {"related_links": {"max_num": 1}}

--- a/ons_alpha/core/blocks/stream_blocks.py
+++ b/ons_alpha/core/blocks/stream_blocks.py
@@ -8,6 +8,7 @@ from ons_alpha.core.blocks import (
     CorrectionBlock,
     DocumentListBlock,
     DocumentsBlock,
+    ExploreMoreBlock,
     HeadingBlock,
     NoticeBlock,
     ONSChartEmbedBlock,
@@ -49,6 +50,7 @@ class CoreStoryBlock(StreamBlock):
         "Use the 'ONS Table' block for the full ONS needs.",
     )
     document_list = DocumentListBlock()
+    explore_more = ExploreMoreBlock()
 
     class Meta:
         block_counts = {"related_links": {"max_num": 1}}

--- a/ons_alpha/jinja2/templates/components/streamfield/document_list_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/document_list_block.html
@@ -1,4 +1,17 @@
-{# Note: this is a list of links not documents - but it uses the design system document list component for styling #}
+{#
+Note: this is a list of links not documents - but it uses the design system
+document list component for styling.
+
+This is used for both the Document List and Explore More StreamField blocks. The
+difference is only in the way the data is passed to the template
+
+- Document List uses the Search Results variant:
+  https://service-manual.ons.gov.uk/design-system/components/document-list#search-results.
+  It includes metadata.
+- Explore More uses the News Articles variant:
+  https://service-manual.ons.gov.uk/design-system/components/document-list#news-articles.
+  It includes thumbnails, and no metadata.
+#}
 {% from "component_overrides/document-list/_macro.njk" import onsDocumentListNew %}
 
 <section id="{{ slug }}" class="document-list-block">

--- a/ons_alpha/topics/models.py
+++ b/ons_alpha/topics/models.py
@@ -15,6 +15,7 @@ from ons_alpha.articles.models import ArticlePage, ArticleSeriesPage
 from ons_alpha.bulletins.models import BulletinPage, BulletinSeriesPage
 from ons_alpha.core.blocks import (
     DocumentListBlock,
+    ExploreMoreBlock,
     FeaturedDocumentBlock,
     FeaturedDocumentWithChartBlock,
     HeadlineFiguresBlock,
@@ -84,6 +85,7 @@ class TopicPage(BaseTopicPage):
             ("featured_document", FeaturedDocumentBlock()),
             ("featured_document_with_chart", FeaturedDocumentWithChartBlock()),
             ("document_list", DocumentListBlock()),
+            ("explore_more", ExploreMoreBlock()),
         ],
         blank=True,
         block_counts={


### PR DESCRIPTION
### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/NWP-584

This adds an "Explore More" block. It is actually a variant implementation of the existing Design System [Document List](https://service-manual.ons.gov.uk/design-system/components/document-list) component.

### How to review
In the Wagtail admin, on a Bulletin page, add an Explore More block to the body.

<details>
<summary>Screenshots</summary>
Admin UI:

![image](https://github.com/user-attachments/assets/25e20da8-7bc8-49e3-9891-fd910d57ba1c)




Rendered:
![image](https://github.com/user-attachments/assets/26ca1249-ba3e-46bc-9dce-67addeddb717)


</details>
