### PR TITLE
fix spacing on section blocks on the bulletin page

### DIFF
--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -107,7 +107,10 @@
             {% for block in page.body %}
                 {% if block.block_type == "heading" %}
                     {% if ns.has_section %} </section>{% endif %}
-                    <section id="{{ block.value|slugify }}">
+                    <section
+                        id="{{ block.value|slugify }}"
+                        class="{% if content_block.block_type !='heading' %}streamfield{% if last_flush %}streamfield--last-flush{% endif %}{% endif %}"
+                    >
                         <h2>{{ block.value }}</h2>
                         {% set ns.has_section = True %}
                 {% else %}

--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -109,12 +109,14 @@
                     {% if ns.has_section %} </section>{% endif %}
                     <section
                         id="{{ block.value|slugify }}"
-                        class="{% if content_block.block_type !='heading' %}streamfield{% if last_flush %}streamfield--last-flush{% endif %}{% endif %}"
+                        class="streamfield {% if last_flush %}streamfield--last-flush{% endif %}"
                     >
                         <h2>{{ block.value }}</h2>
                         {% set ns.has_section = True %}
                 {% else %}
-                    {% include_block block %}
+                    <div class="streamfield {% if loop.last %}streamfield--last-flush{% endif %}">
+                        {% include_block block %}
+                    </div>
                 {% endif %}
             {% endfor %}
 

--- a/ons_alpha/static_src/sass/components/_document-list-block.scss
+++ b/ons_alpha/static_src/sass/components/_document-list-block.scss
@@ -12,4 +12,8 @@
     &__title {
         @include heading-2();
     }
+
+    .streamfield & {
+        margin-bottom: 0;
+    }
 }


### PR DESCRIPTION
### What is the context of this PR?
After updating the section markup in https://github.com/ONSdigital/dis-wagtail-alpha/pull/160, a further spacing fix was needed to ensure that the original spacing of streamfield blocks is followed.

### How to review
Check out this branch on a local build and make sure that each heading + content block is separated by 4 rems of spacing. If there is no contact details block on the page, the last streamfield block will not have a bottom margin set.
