### PR TITLE
Revert previous attempt to fix the section markup as it impacts on the spacing

### DIFF
--- a/ons_alpha/jinja2/templates/pages/bulletin_page.html
+++ b/ons_alpha/jinja2/templates/pages/bulletin_page.html
@@ -102,20 +102,7 @@
                 {% set last_flush = True %}
             {% endif %}
 
-            {# see https://jinja.palletsprojects.com/en/stable/templates/#assignments #}
-            {% set ns = namespace(has_section=false) %}
-            {% for block in page.body %}
-                {% if block.block_type == "heading" %}
-                    {% if ns.has_section %} </section>{% endif %}
-                    <section id="{{ block.value|slugify }}">
-                        <h2>{{ block.value }}</h2>
-                        {% set ns.has_section = True %}
-                {% else %}
-                    {% include_block block %}
-                {% endif %}
-            {% endfor %}
-
-            {% if ns.has_section %}</section>{% endif %}
+            {% include_block page.body %}
 
             {% if page.contact_details %}
                 <section id="contact-details">


### PR DESCRIPTION
## What is the context of this PR?
The previous changes to the section markup on the bulletin page caused a problem with the spacing between streamfield blocks. We nearly had a solution for this but it felt a bit risky just before a release, so we will live with the broken section highlighting on the bulletin page for now.

## How to review
Test a bulletin page in your local build. The spacing should all be fine, but the section highlighting won't work.
Test a topic page. The spacing should all be fine, and the section highlighting should work.
