### PR TITLE
Set the correct thumbnail size for the news variant of the document list pattern

### DIFF
--- a/ons_alpha/core/blocks/explore_more.py
+++ b/ons_alpha/core/blocks/explore_more.py
@@ -1,12 +1,7 @@
 from django.utils.html import format_html, strip_tags
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
-from wagtail.blocks import (
-    CharBlock,
-    ListBlock,
-    StructBlock,
-    TextBlock,
-)
+from wagtail.blocks import CharBlock, ListBlock, StructBlock, TextBlock
 from wagtail.images.blocks import ImageChooserBlock
 
 
@@ -55,9 +50,9 @@ class ExploreMoreBlock(StructBlock):
                 "metadata": {},
                 "thumbnail": {
                     # standard: 136×96
-                    # high-dpi: 192×272
+                    # high-dpi: 272×192
                     "smallSrc": item["thumbnail"].get_rendition("fill-136x96").url,
-                    "largeSrc": item["thumbnail"].get_rendition("fill-192x272").url,
+                    "largeSrc": item["thumbnail"].get_rendition("fill-272x192").url,
                 },
             }
             documents.append(document)


### PR DESCRIPTION
### What is the context of this PR?
The larger thumbnail image for 'explore more' was being cropped to the wrong size. See https://service-manual.ons.gov.uk/design-system/components/document-list#news-article-thumbnail-images - we needed to use the correct size for the 'news' variation.

### How to review
Check out this branch and add an "explore more" streamfield item to a topic page. Ensure the image is displayed as landscape when viewed on a retina screen.
