### PR TITLE
Update streamfield fields for Headline Figures and Explore More

### DIFF
--- a/ons_alpha/core/blocks/explore_more.py
+++ b/ons_alpha/core/blocks/explore_more.py
@@ -1,7 +1,8 @@
+from django.core.exceptions import ValidationError
 from django.utils.html import format_html, strip_tags
 from django.utils.text import slugify
 from django.utils.translation import gettext as _
-from wagtail.blocks import CharBlock, ListBlock, StructBlock, TextBlock
+from wagtail.blocks import CharBlock, ListBlock, PageChooserBlock, StructBlock, TextBlock, URLBlock
 from wagtail.images.blocks import ImageChooserBlock
 
 
@@ -9,6 +10,16 @@ class ExploreMoreListItemBlock(StructBlock):
     title = CharBlock(label=_("Title"), max_length=200, required=True)
     thumbnail = ImageChooserBlock(label=_("Thumbnail"), required=True)
     description = TextBlock(label=_("Description"), max_length=300, required=True)
+    page = PageChooserBlock(
+        label=_("Page"),
+        required=False,
+        help_text=_("Select a page to link to. This will be used as the URL."),
+    )
+    external_link = URLBlock(
+        label=_("External link"),
+        required=False,
+        help_text=_("Enter an external URL to link to."),
+    )
 
     class Meta:
         icon = "list-ul"
@@ -17,6 +28,9 @@ class ExploreMoreListItemBlock(StructBlock):
     def clean(self, value):
         value = super().clean(value)
         value["description"] = strip_tags(value["description"])
+        # Ensure only one of page or external_link is provided
+        if value["page"] and value["external_link"]:
+            raise ValidationError(_("You cannot provide both a page and an external link at the same time."))
         return value
 
 
@@ -45,6 +59,7 @@ class ExploreMoreBlock(StructBlock):
             document = {
                 "title": {
                     "text": item["title"],
+                    "url": item["page"].url if item["page"] else item["external_link"],
                 },
                 "description": format_html("<p>{}</p>", item["description"]),
                 "metadata": {},

--- a/ons_alpha/core/blocks/headline_figures.py
+++ b/ons_alpha/core/blocks/headline_figures.py
@@ -1,5 +1,6 @@
 from django.utils.translation import gettext as _
 from wagtail.blocks import CharBlock, ListBlock, PageChooserBlock, StructBlock
+from wagtail.images.blocks import ImageChooserBlock
 
 
 class HeadlineFiguresItemBlock(StructBlock):
@@ -7,6 +8,13 @@ class HeadlineFiguresItemBlock(StructBlock):
     title_link = PageChooserBlock(required=False)
     figure = CharBlock(label=_("Figure"), max_length=10, required=True)
     supporting_text = CharBlock(label=_("Supporting text"), max_length=100, required=False)
+    image = ImageChooserBlock(label=_("Image"), required=False)
+    image_caption = CharBlock(
+        label=_("Image caption"),
+        max_length=100,
+        required=False,
+        help_text=_("Will only be used if an image is provided"),
+    )
 
 
 class HeadlineFiguresBlock(ListBlock):

--- a/ons_alpha/core/blocks/headline_figures.py
+++ b/ons_alpha/core/blocks/headline_figures.py
@@ -9,12 +9,6 @@ class HeadlineFiguresItemBlock(StructBlock):
     figure = CharBlock(label=_("Figure"), max_length=10, required=True)
     supporting_text = CharBlock(label=_("Supporting text"), max_length=100, required=False)
     image = ImageChooserBlock(label=_("Image"), required=False)
-    image_caption = CharBlock(
-        label=_("Image caption"),
-        max_length=100,
-        required=False,
-        help_text=_("Will only be used if an image is provided"),
-    )
 
 
 class HeadlineFiguresBlock(ListBlock):

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -12,6 +12,15 @@
                         </a>
                     {% endif %}
                 </h3>
+                {% if figure.image %}
+                    <figure class="headline-figures__image-container">
+                        {% if figure.image_caption %}
+                            <figcaption class="headline-figures__image-caption">{{ figure.image_caption }}</figcaption>
+                        {% endif %}
+                        {{ srcset_image(figure.image, "format-png|width-{278,556}", class="headline-figures__image") }}
+                    </figure>
+                {% endif %}
+
                 <p class="headline-figures__figure">{{ figure.figure }}</p>
 
                 {% if figure.supporting_text %}

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -14,9 +14,6 @@
                 </h3>
                 {% if figure.image %}
                     <figure class="headline-figures__image-container">
-                        {% if figure.image_caption %}
-                            <figcaption class="headline-figures__image-caption">{{ figure.image_caption }}</figcaption>
-                        {% endif %}
                         {{ srcset_image(figure.image, "format-png|width-{278,556}", class="headline-figures__image") }}
                     </figure>
                 {% endif %}

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -88,10 +88,6 @@
         margin: 0 0 1rem 0;
     }
 
-    &__image-caption {
-        font-size: 0.8em;
-    }
-
     &__figure {
         // font-sizes don't match design system type scale in the figma file
         font-size: rem-sizing(32);

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -84,6 +84,14 @@
         }
     }
 
+    &__image-container {
+        margin: 0 0 1rem 0;
+    }
+
+    &__image-caption {
+        font-size: 0.8em;
+    }
+
     &__figure {
         // font-sizes don't match design system type scale in the figma file
         font-size: rem-sizing(32);


### PR DESCRIPTION
### What is the context of this PR?
This PR addresses NWP-595 and NWP-596. It introduces an image field to the Headline Figures component, and a page/external link field to the Explore More component.

### How to review
* Checkout branch
* Create a topic or bulletin page
* Add a Headline Figures block
* Check that an image can be added
* Add an Explore More block
* Check that both a page and an external link can be added

### Follow-up tasks
The styling needs to be adjusted once we receive the images.