### PR TITLE
Add image caption to headline figures block

### DIFF
--- a/ons_alpha/core/blocks/headline_figures.py
+++ b/ons_alpha/core/blocks/headline_figures.py
@@ -9,6 +9,7 @@ class HeadlineFiguresItemBlock(StructBlock):
     figure = CharBlock(label=_("Figure"), max_length=10, required=True)
     supporting_text = CharBlock(label=_("Supporting text"), max_length=100, required=False)
     image = ImageChooserBlock(label=_("Image"), required=False)
+    image_caption = CharBlock(label=_("Image caption"), max_length=100, required=False)
 
 
 class HeadlineFiguresBlock(ListBlock):

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -14,7 +14,7 @@
                 </h3>
                 {% if figure.image %}
                     <figure class="headline-figures__image-container">
-                        <figcaption class="headline-figures__image-caption">{{figure.image_caption}}</figcaption>
+                        <figcaption class="headline-figures__image-caption">{{ figure.image_caption }}</figcaption>
                         {{ srcset_image(figure.image, "format-png|width-{278,556}", class="headline-figures__image") }}
                     </figure>
                 {% endif %}

--- a/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
+++ b/ons_alpha/jinja2/templates/components/streamfield/headline_figures_block.html
@@ -14,6 +14,7 @@
                 </h3>
                 {% if figure.image %}
                     <figure class="headline-figures__image-container">
+                        <figcaption class="headline-figures__image-caption">{{figure.image_caption}}</figcaption>
                         {{ srcset_image(figure.image, "format-png|width-{278,556}", class="headline-figures__image") }}
                     </figure>
                 {% endif %}

--- a/ons_alpha/static_src/sass/components/_headline-figures.scss
+++ b/ons_alpha/static_src/sass/components/_headline-figures.scss
@@ -88,6 +88,10 @@
         margin: 0 0 1rem 0;
     }
 
+    &__image-caption {
+        font-size: 0.8em;
+    }
+
     &__figure {
         // font-sizes don't match design system type scale in the figma file
         font-size: rem-sizing(32);


### PR DESCRIPTION
### What is the context of this PR?
This PR relates to NWP-596 and adds an image caption to the headline figures block. 

### How to review
* Checkout code
* Go to admin panel
* Add a headline figure block
* Notice that an image caption can be added
* Verify that it appears on the page
